### PR TITLE
Update to tmi.js v1.1.1

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,4 @@
 [twitch]
-cluster = aws
 username = sogeBot
 ; get oauth password http://twitchapps.com/tmi/
 password = 

--- a/libs/systems/points.js
+++ b/libs/systems/points.js
@@ -39,13 +39,13 @@ function Points () {
 }
 
 Points.prototype.addEvents = function (self) {
-  global.client.on('join', function (channel, username) {
-    if (username !== global.configuration.get().twitch.username) {
+  global.client.on('join', function (channel, username, fromSelf) {
+    if (!fromSelf) {
       self.startCounting(username)
     }
   })
-  global.client.on('part', function (channel, username) {
-    if (username !== global.configuration.get().twitch.username) {
+  global.client.on('part', function (channel, username, fromSelf) {
+    if (!fromSelf) {
       self.stopCounting(username)
     }
   })

--- a/libs/twitch.js
+++ b/libs/twitch.js
@@ -11,8 +11,7 @@ function Twitch () {
   var self = this
   setInterval(function () {
     global.client.api({
-      url: 'https://api.twitch.tv/kraken/streams/' + global.configuration.get().twitch.owner,
-      json: true
+      url: 'https://api.twitch.tv/kraken/streams/' + global.configuration.get().twitch.owner
     }, function (err, res, body) {
       if (err) console.log(err)
       if (body.stream) {

--- a/main.js
+++ b/main.js
@@ -25,7 +25,6 @@ var options = {
     debug: false
   },
   connection: {
-    cluster: global.configuration.get().twitch.cluster,
     reconnect: true
   },
   identity: {

--- a/main.js
+++ b/main.js
@@ -43,8 +43,6 @@ global.systems = require('auto-load')('./libs/systems/')
 global.client.connect()
 
 global.client.on('connected', function (address, port) {
-  global.client.raw('CAP REQ :twitch.tv/commands')
-  global.client.raw('CAP REQ :twitch.tv/membership')
   global.client.color('Firebrick')
 })
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment-precise-range-plugin": "^1.2.0",
     "nedb": "^1.8.0",
     "socket.io": "^1.4.6",
-    "tmi.js": "1.0.0",
+    "tmi.js": "^1.1.1",
     "winston": "^2.2.0",
     "ytdl-core": "^0.7.16"
   },


### PR DESCRIPTION
There's no need to specify a cluster, join/part events have a simplification for detecting itself, API requests are automatically set for JSON, and tmi.js already sends the capability requests to Twitch [here](https://github.com/tmijs/tmi.js/blob/3ab4ab20db32299ccfd4e98b957077df90f5a671/lib/client.js#L900).

[Documentation for tmi.js v1.1.1 can be found here.](https://docs.tmijs.org/v1.1.1/)