### PR TITLE
users: re-add !merge

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -993,10 +993,9 @@
     }
   },
   "merge": {
-    "noUsername": "$sender, musis zadat uzivatelske jmeno!",
-    "success": "$sender, $username ma nyni data $merged-username",
-    "noID": "$sender, pro toto uzivatelske jmeno neexistuje ID, proto nelze zmenit",
-    "noUsernameToMerge": "$sender, nebylo nalezeno jine uzivatelske jmeno"
+    "no-from-user-set": "$sender, musi byt zadan uzivatel, ze ktereho se budou brat data",
+    "no-to-user-set": "$sender, musi byt zadan uzivatel, kteremu se predaji data",
+    "user-merged": "$sender, uzivatel $fromUsername byl nakopirovan uzivateli $toUsername"
   },
   "highlights": {
     "saved": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -993,10 +993,9 @@
     }
   },
   "merge": {
-    "noUsername": "$sender, you need to specify username to merge",
-    "success": "$sender, $username have now data of $merged-username",
-    "noID": "$sender, specified username doesn't have ID and cannot be merged",
-    "noUsernameToMerge": "$sender, no other username was found to merge"
+    "no-from-user-set": "$sender, you need to specify from which username to merge",
+    "no-to-user-set": "$sender, you need to specify to which username merge",
+    "user-merged": "$sender, user $fromUsername was merged to $toUsername"
   },
   "highlights": {
     "saved": {


### PR DESCRIPTION
`!merge` is updated with new syntax and is simpler. It will not basically merge all data, just 'rename' user to a new one

New syntax to use `!merge`:
`!merge -from user1 -to user2`

_ref: #496, #418 