### PR TITLE
twitch, users: sub length fixes, !subs and !followers

### DIFF
--- a/libs/users.js
+++ b/libs/users.js
@@ -33,11 +33,7 @@ function Users () {
       this.rate_limit_follower_check = _.uniq(this.rate_limit_follower_check)
       this.isFollowerUpdate(this.rate_limit_follower_check.shift())
     }
-    if (this.rate_limit_subscriber_check.length > 0) {
-      this.rate_limit_subscriber_check = _.uniq(this.rate_limit_subscriber_check)
-      this.getSubLengthUpdate(this.rate_limit_subscriber_check.shift())
-    }
-  }, 2000) // run follower ONE request every 2 second
+  }, 1000) // run follower ONE request every 1 second
 
   setInterval(async () => {
     let increment = this.increment
@@ -205,10 +201,6 @@ Users.prototype.delete = function (username) {
   global.db.engine.remove('users', { username: username })
 }
 
-Users.prototype.getSubLength = async function (username) {
-  global.users.rate_limit_subscriber_check.push(username)
-}
-
 Users.prototype.isFollower = async function (username) {
   let user = await global.users.get(username)
   if (new Date().getTime() - user.time.followCheck < 1000 * 60 * 30) { // check can be performed _only_ every 30 minutes
@@ -216,37 +208,6 @@ Users.prototype.isFollower = async function (username) {
   }
 
   global.users.rate_limit_follower_check.push(username)
-}
-
-Users.prototype.getSubLengthUpdate = async function (username) {
-  const d = require('debug')('users:getSubLengthUpdate')
-
-  if (_.isNil(config.settings.broadcaster_oauth) || !config.settings.broadcaster_oauth.match(/oauth:[\w]*/)) {
-    d('Broadcaster oauth is not properly set - subscribers cannot be checked')
-    return
-  }
-
-  let user = await global.users.get(username)
-  if (_.isNil(user.id)) return // skip check if ID doesn't exist
-
-  const url = `https://api.twitch.tv/kraken/channels/${global.channelId}/subscriptions/${user.id}`
-  try {
-    d('getSubLengthUpdate check for user %s', username)
-    var request = await snekfetch.get(url)
-      .set('Accept', 'application/vnd.twitchtv.v5+json')
-      .set('Authorization', 'OAuth ' + config.settings.broadcaster_oauth.split(':')[1])
-      .set('Client-ID', config.settings.client_id)
-    global.db.engine.insert('APIStats', { timestamp: _.now(), call: 'getSubLengthUpdate', api: 'kraken', endpoint: url, code: request.status })
-    d('Request done: %j', request.body)
-  } catch (e) {
-    global.log.error(`API: ${url} - ${e.message}`)
-    global.db.engine.insert('APIStats', { timestamp: _.now(), call: 'getSubLengthUpdate', api: 'kraken', endpoint: url, code: e.message })
-    return
-  }
-
-  if (!_.isNil(request.body.created_at)) {
-    global.users.set(username, { time: { subscribed_at: moment(request.body.created_at).format('X') * 1000 } })
-  }
 }
 
 Users.prototype.isFollowerUpdate = async function (username) {

--- a/libs/webhooks.js
+++ b/libs/webhooks.js
@@ -124,15 +124,23 @@ class Webhooks {
         .set('Client-ID', config.settings.client_id)
         .set('Authorization', 'OAuth ' + config.settings.bot_oauth.split(':')[1])
       debug('user API data" %o', userGetFromApi.body)
+
+      // save followed_at to cache
+      let cache = await global.twitch.cached()
+      cache.time.followed_at = moment().format('x')
+
       global.events.fire('follow', { username: userGetFromApi.body.data[0].login }) // we can safely fire event as user doesn't exist in db
-      await global.db.engine.insert('users', { id: fid, username: userGetFromApi.body.data[0].login, is: { follower: true }, time: { followCheck: new Date().getTime(), follow: moment().format('X') * 1000 } })
+      await Promise.all([
+        global.twitch.cached(cache),
+        global.db.engine.insert('users', { id: fid, username: userGetFromApi.body.data[0].login, is: { follower: true }, time: { followCheck: new Date().getTime(), follow: moment().format('x') } })
+      ])
     } else {
       debug('user in db')
-      debug('username: %s, is follower: %s, current time: %s, user time follow: %s', user.username, user.is.follower, moment().format('X') * 1000, user.time.follow)
-      if (!user.is.follower && moment().format('X') * 1000 - user.time.follow > 60000 * 60) global.events.fire('follow', { username: user.username })
+      debug('username: %s, is follower: %s, current time: %s, user time follow: %s', user.username, user.is.follower, moment().format('x'), user.time.follow)
+      if (!user.is.follower && moment().format('x') - user.time.follow > 60000 * 60) global.events.fire('follow', { username: user.username })
 
       if (user.is.follower) global.users.set(user.username, {id: fid, time: { followCheck: new Date().getTime() }})
-      else global.users.set(user.username, { id: fid, is: { follower: true }, time: { followCheck: new Date().getTime(), follow: moment().format('X') * 1000 } })
+      else global.users.set(user.username, { id: fid, is: { follower: true }, time: { followCheck: new Date().getTime(), follow: moment().format('x') } })
     }
   }
 

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -1026,5 +1026,7 @@
   "phillipsHue": {
     "list": "$sender, Seznam pripojenych Phillips Hue zarovek: "
   },
-  "time": "Aktualni cas streamera v jeho casove zone je $time"
+  "time": "Aktualni cas streamera v jeho casove zone je $time",
+  "subs": "$sender, je zde prave $onlineSubCount online subscriberu. Posledni sub/resub byl $lastSubUsername $lastSubAgo",
+  "followers": "$sender, je zde prave $onlineFollowersCount online followeru. Posledni follow byl $lastFollowUsername $lastFollowAgo"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1026,5 +1026,7 @@
   "phillipsHue": {
     "list": "$sender, List of Phillips Hue connected lights: "
   },
-  "time": "Current streamers time in his timezone is $time"
+  "time": "Current streamers time in his timezone is $time",
+  "subs": "$sender, there is currently $onlineSubCount online subscribers. Last sub/resub was $lastSubUsername $lastSubAgo",
+  "followers": "$sender, there is currently $onlineFollowersCount online followers. Last follow was $lastFollowUsername $lastFollowAgo"
 }

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@
 var irc = require('twitch-js')
 var _ = require('lodash')
 const figlet = require('figlet')
+const moment = require('moment')
 
 // config
 const config = require('./config.json')
@@ -152,7 +153,6 @@ global.client.on('message', async function (channel, sender, message, fromSelf) 
         const user = await global.users.get(sender.username)
 
         if (!_.isNil(user.id)) global.users.isFollower(user.username)
-        if (_.get(sender, 'subscriber', false) && _.isNil(user.time.subscribed_at)) global.users.getSubLength(user.username)
         if (!message.startsWith('!')) global.users.messagesInc(user.username)
 
         // set is.mod
@@ -259,10 +259,11 @@ global.client.on('clearchat', function (channel) {
 
 global.client.on('subscription', async function (channel, username, method) {
   if (debug.enabled) debug('Subscription: %s from %s', username, method)
-  global.users.set(username, { is: { subscriber: true } })
+  global.users.set(username, { is: { subscriber: true }, time: { subscribed_at: moment().format('x') } })
   global.events.fire('subscription', { username: username, method: (!_.isNil(method.prime) && method.prime) ? 'Twitch Prime' : '' })
 
   let cached = await global.twitch.cached()
+  cached.time.subscribed_at = moment().format('x')
   cached.subscribers.unshift(username)
   cached.subscribers = _.chunk(global.twitch.cached.subscribers, 100)[0]
   await global.twitch.cached(cached)
@@ -270,10 +271,11 @@ global.client.on('subscription', async function (channel, username, method) {
 
 global.client.on('resub', async function (channel, username, months, message) {
   if (debug.enabled) debug('Resub: %s (%s months) - %s', username, months, message)
-  global.users.set(username, { is: { subscriber: true } })
+  global.users.set(username, { is: { subscriber: true }, time: { subscribed_at: moment().substract(months, 'months').format('x') } })
   global.events.fire('resub', { username: username, monthsName: global.parser.getLocalizedName(months, 'core.months'), months: months, message: message })
 
   let cached = await global.twitch.cached()
+  cached.time.subscribed_at = moment().format('x')
   cached.subscribers.unshift(username)
   cached.subscribers = _.chunk(global.twitch.cached.subscribers, 100)[0]
   await global.twitch.cached(cached)


### PR DESCRIPTION
Removed API sub length check, as `created_at` was not correct (always less than month because it got reset on resub), so we will need to get data from sub/resub events

Also added `!followers`, `!subs` commands #334 