### PR TITLE
lib/message: Force return empty qs if param is null

### DIFF
--- a/libs/message.js
+++ b/libs/message.js
@@ -474,7 +474,7 @@ class Message {
     await this.parseMessageEach(math); d('parseMessageEach: %s', this.message)
     await this.parseMessageOnline(online); d('parseMessageOnline: %s', this.message)
     await this.parseMessageCommand(command); d('parseMessageCommand: %s', this.message)
-    await this.parseMessageEach(qs); d('parseMessageEach: %s', this.message)
+    await this.parseMessageEach(qs, false); d('parseMessageEach: %s', this.message)
     await this.parseMessageEach(list); d('parseMessageEach: %s', this.message)
     await this.parseMessageEach(stream); d('parseMessageEach: %s', this.message)
     await this.parseMessageApi(); d('parseMessageApi: %s', this.message)


### PR DESCRIPTION
###### FEATURES & DESCRIPTION
- [ ] empty qs if param is null
  - Force return empty qs if param is null

###### ISSUES REFS

###### CHECKLIST
- [ ] Added tests _if applicable_
- [ ] Test Passing
- [ ] Docs Updated _if applicable_
- [ ] Translations added
- [ ] Commits Squashed
