### PR TITLE
Custom variables refactor

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -26,6 +26,7 @@ function cluster () {
   global.currency = new (require('./libs/currency.js'))()
   global.users = new (require('./libs/users.js'))()
   global.events = new (require('./libs/events.js'))()
+  global.customvariables = new (require('./libs/customvariables.js'))()
   global.twitch = new (require('./libs/twitch'))()
   global.permissions = new (require('./libs/permissions'))()
   global.api = new (require('./libs/api'))()

--- a/dist/js/commons.js
+++ b/dist/js/commons.js
@@ -250,5 +250,14 @@ var commons = {
   unconfirm: function (el) {
     $(el).parent().children(".btn-confirm").css('display', 'none')
     $(el).parent().children(".btn-remove").css('display', 'inline-block')
+  },
+  urlParam: function (name){
+    var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
+    if (results == null){
+      return null;
+    }
+    else {
+      return decodeURI(results[1]) || 0;
+    }
   }
 }

--- a/libs/api.js
+++ b/libs/api.js
@@ -655,10 +655,14 @@ class API {
     const match = title.match(regexp)
 
     if (!_.isNil(match)) {
-      for (let variable of title.match(regexp).map((o) => o.replace('$_', ''))) {
-        let variableFromDb = await global.db.engine.findOne('customvars', { key: variable })
-        if (_.isNil(variableFromDb.key)) variableFromDb = { key: variable, value: global.translate('webpanel.not-available') }
-        title = title.replace(new RegExp(`\\$_${variableFromDb.key}`, 'g'), variableFromDb.value)
+      for (let variable of title.match(regexp)) {
+        let value
+        if (await global.customvariables.isVariableSet(variable)) {
+          value = await global.customvariables.getValueOf(variable)
+        } else {
+          value = global.translate('webpanel.not-available')
+        }
+        title = title.replace(new RegExp(`\\${variable}`, 'g'), value)
       }
     }
     return title

--- a/libs/commons.js
+++ b/libs/commons.js
@@ -104,9 +104,11 @@ Commons.prototype.sendMessage = async function (message, sender, attr) {
 
   if (_.isString(sender)) sender = { username: sender }
   if (_.isNil(sender) || _.isNil(sender.username)) sender.username = undefined
+  else attr.sender = sender.username
   if (!_.isNil(sender.quiet)) attr.quiet = sender.quiet
-  attr.sender = sender.username
-  message = await new Message(message).parse(attr)
+  if (!_.isNil(sender.skip)) attr.skip = sender.skip
+
+  if (!attr.skip) message = await new Message(message).parse(attr)
   if (message === '') return false // if message is empty, don't send anything
 
   // if sender is null/undefined, we can assume, that username is from dashboard -> bot

--- a/libs/customvariables.js
+++ b/libs/customvariables.js
@@ -1,0 +1,286 @@
+'use strict'
+
+const _ = require('lodash')
+const debug = require('debug')
+const crypto = require('crypto')
+const safeEval = require('safe-eval')
+const snekfetch = require('snekfetch')
+const cluster = require('cluster')
+const mathjs = require('mathjs')
+
+const Timeout = require('./timeout')
+
+const DEBUG = {
+  SOCKETS: debug('events:sockets'),
+  SCRIPT: debug('events:runScript')
+}
+
+class CustomVariables {
+  constructor () {
+    if (cluster.isMaster) {
+      this.addMenuAndListenersToPanel()
+      this.checkIfCacheOrRefresh()
+    }
+  }
+
+  async addMenuAndListenersToPanel () {
+    if (_.isNil(global.panel)) return new Timeout().recursive({ this: this, uid: `${this.constructor.name}.addMenuAndListenersToPanel`, wait: 1000, fnc: this.addMenuAndListenersToPanel })
+    global.panel.addMenu({category: 'registry', name: 'custom-variables', id: 'registry.customVariables'})
+    this.sockets()
+  }
+
+  sockets () {
+    const io = global.panel.io.of('/registry/customVariables')
+
+    io.on('connection', (socket) => {
+      DEBUG.SOCKETS('Socket /registry/customVariables connected, registering sockets')
+      socket.on('list.variables', async (cb) => {
+        let variables = await global.db.engine.find('custom.variables')
+        cb(null, variables); DEBUG.SOCKETS('list.variables => %j', variables)
+      })
+      socket.on('run.script', async (_id, cb) => {
+        let item
+        try {
+          item = await global.db.engine.findOne('custom.variables', { _id: String(_id) })
+          item = await global.db.engine.update('custom.variables', { _id: String(_id) }, { currentValue: await this.runScript(item.evalValue, {}), runAt: new Date() })
+        } catch (e) {
+          cb(e.stack, null)
+        }
+        cb(null, item)
+      })
+      socket.on('test.script', async (script, cb) => {
+        let returnedValue
+        try {
+          returnedValue = await this.runScript(script, { sender: 'TestUser' })
+        } catch (e) {
+          cb(e.stack, null)
+        }
+        cb(null, returnedValue)
+      })
+      socket.on('isUnique', async (variable, cb) => {
+        cb(null, _.isEmpty(await global.db.engine.findOne('custom.variables', { variableName: String(variable) })))
+      })
+      socket.on('delete', async (id, cb) => {
+        await global.db.engine.remove('custom.variables', { _id: String(id) })
+        await global.db.engine.remove('custom.variables.watch', { variableId: String(id) }) // force unwatch
+        this.updateWidgetAndTitle()
+        cb()
+      })
+      socket.on('load', async (id, cb) => {
+        let variable = await global.db.engine.findOne('custom.variables', { _id: String(id) })
+        cb(variable); DEBUG.SOCKETS('load => %j', variable)
+      })
+      socket.on('save', async (data, cb) => {
+        var _id
+        try {
+          if (!_.isNil(data._id)) {
+            _id = String(data._id); delete (data._id)
+            await global.db.engine.update('custom.variables', { _id }, data)
+            this.updateWidgetAndTitle(data.variableName)
+          } else {
+            delete (data._id)
+            let item = await global.db.engine.insert('custom.variables', data)
+            _id = String(item._id)
+            this.updateWidgetAndTitle(data.variableName)
+          }
+          cb(null, _id)
+        } catch (e) {
+          cb(e.stack, _id)
+        }
+      })
+    })
+  }
+
+  async runScript (script, opts) {
+    DEBUG.SCRIPT('Start')
+    DEBUG.SCRIPT(script)
+
+    let sender = !_.isNil(opts.sender) ? opts.sender : null
+    let param = !_.isNil(opts.param) ? opts.param : null
+
+    // we need to check +1 variables, as they are part of commentary
+    const containUsers = !_.isNil(script.match(/users/g)) && script.match(/users/g).length > 1
+    const containRandom = !_.isNil(script.replace(/Math\.random|_\.random/g, '').match(/random/g)) && script.match(/users/g).length > 1
+    const containOnline = !_.isNil(script.match(/online/g))
+    const containUrl = !_.isNil(script.match(/url\(['"](.*?)['"]\)/g))
+    DEBUG.SCRIPT('contain users: %s', containUsers)
+    DEBUG.SCRIPT('contain random: %s', containRandom)
+    DEBUG.SCRIPT('contain online: %s', containOnline)
+    DEBUG.SCRIPT('contain url: %s', containUrl)
+
+    for (let match of script.match(/(\$_[a-zA-Z_]+)/g)) {
+      script = script.replace(match, await this.getValueOf(match))
+    }
+
+    let urls = []
+    if (containUrl) {
+      for (let match of script.match(/url\(['"](.*?)['"]\)/g)) {
+        const id = 'url' + crypto.randomBytes(64).toString('hex').slice(0, 5)
+        const url = match.replace(/url\(['"]|["']\)/g, '')
+        let response = await snekfetch.get(url)
+        try {
+          response.body = JSON.parse(response.body.toString())
+        } catch (e) {
+          // JSON failed, treat like string
+          response = response.body.toString()
+        }
+        urls.push({ id, response })
+        script = script.replace(match, id)
+      }
+    }
+
+    let users = []
+    if (containUsers || containRandom) {
+      users = await global.users.getAll()
+    }
+
+    let onlineViewers = []
+    let onlineSubscribers = []
+    let onlineFollowers = []
+
+    if (containOnline) {
+      onlineViewers = await global.db.engine.find('users.online')
+
+      for (let viewer of onlineViewers) {
+        let user = await global.db.engine.find('users', { username: viewer.username, is: { subscriber: true } })
+        if (!_.isEmpty(user)) onlineSubscribers.push(user.username)
+      }
+
+      for (let viewer of onlineViewers) {
+        let user = await global.db.engine.find('users', { username: viewer.username, is: { follower: true } })
+        if (!_.isEmpty(user)) onlineFollowers.push(user.username)
+      }
+    }
+
+    let randomVar = {
+      online: {
+        viewer: _.sample(_.map(onlineViewers, 'username')),
+        follower: _.sample(_.map(onlineFollowers, 'username')),
+        subscriber: _.sample(_.map(onlineSubscribers, 'username'))
+      },
+      viewer: _.sample(_.map(users, 'username')),
+      follower: _.sample(_.map(_.filter(users, (o) => _.get(o, 'is.follower', false)), 'username')),
+      subscriber: _.sample(_.map(_.filter(users, (o) => _.get(o, 'is.subscriber', false)), 'username'))
+    }
+
+    let toEval = `(function evaluation () {  ${script} })()`
+    let context = {
+      _: _,
+      users: users,
+      random: randomVar,
+      sender: await global.configuration.getValue('atUsername') ? `@${sender}` : `${sender}`,
+      param: param
+    }
+
+    if (containUrl) {
+      // add urls to context
+      for (let url of urls) {
+        context[url.id] = url.response
+      }
+    }
+    DEBUG.SCRIPT(toEval); return (safeEval(toEval, context))
+  }
+
+  async isVariableSet (variableName) {
+    let item = await global.db.engine.findOne('custom.variables', { variableName })
+    return !_.isEmpty(item) ? String(item._id) : null
+  }
+
+  async isVariableSetById (_id) {
+    let item = await global.db.engine.findOne('custom.variables', { _id })
+    return !_.isEmpty(item) ? String(item.variableName) : null
+  }
+
+  async getValueOf (variableName, opts) {
+    if (!variableName.startsWith('$_')) variableName = `$_${variableName}`
+    let item = await global.db.engine.findOne('custom.variables', { variableName })
+    if (_.isEmpty(item)) return '' // return empty if variable doesn't exist
+
+    if (item.type === 'eval' && Number(item.runEvery) === 0) {
+      item.currentValue = await this.runScript(item.evalValue, opts)
+      await global.db.engine.update('custom.variables', { variableName }, { currentValue: item.currentValue, runAt: new Date() })
+    }
+
+    return item.currentValue
+  }
+
+  /* Sets value of variable with proper checks
+   *
+   * @return object
+   * { updated, isOK }
+   */
+  async setValueOf (variableName, currentValue, opts) {
+    let item = await global.db.engine.findOne('custom.variables', { variableName })
+    let isOk = true
+    let isEval = false
+
+    opts.sender = _.isNil(opts.sender) ? null : opts.sender
+
+    // add simple text variable, if not existing
+    if (_.isEmpty(item)) {
+      item = await global.db.engine.insert('custom.variables', { variableName, currentValue, type: 'text' })
+    } else {
+      if (item.readOnly) {
+        isOk = false
+      } else {
+        if (item.type === 'number') {
+          if (['+', '-'].includes(currentValue)) {
+            currentValue = mathjs.eval(`${item.currentValue} ${currentValue} 1`)
+          } else {
+            const isNumber = _.isFinite(Number(currentValue))
+            isOk = isNumber
+            currentValue = isNumber ? Number(currentValue) : item.currentValue
+          }
+        } else if (item.type === 'options') {
+          // check if is in usableOptions
+          let isUsableOption = item.usableOptions.split(',').map((o) => o.trim()).includes(currentValue)
+          isOk = isUsableOption
+          currentValue = isUsableOption ? currentValue : item.currentValue
+        } else if (item.type === 'eval') {
+          opts.param = currentValue
+          item.currentValue = await this.getValueOf(variableName, opts)
+          isEval = true
+        }
+        // do update only on non-eval variables
+        if (item.type !== 'eval' && isOk) item = await global.db.engine.update('custom.variables', { variableName }, { currentValue })
+      }
+    }
+
+    if (isOk) this.updateWidgetAndTitle(variableName)
+    return { updated: item, isOk, isEval }
+  }
+
+  async checkIfCacheOrRefresh () {
+    let items = await global.db.engine.find('custom.variables', { type: 'eval' })
+
+    for (let item of items) {
+      try {
+        item.runAt = _.isNil(item.runAt) ? 0 : item.runAt
+        const shouldRun = item.runEvery > 0 && new Date().getTime() - new Date(item.runAt).getTime() >= item.runEvery
+        if (shouldRun) {
+          let newValue = await this.runScript(item.evalValue, {})
+          await global.db.engine.update('custom.variables', { _id: String(item._id) }, { runAt: new Date(), currentValue: newValue })
+          await this.updateWidgetAndTitle(item.variableName)
+        }
+      } catch (e) {} // silence errors
+    }
+    return new Timeout().recursive({ this: this, uid: `${this.constructor.name}.checkIfCacheOrRefresh`, wait: 1000, fnc: this.checkIfCacheOrRefresh })
+  }
+
+  async updateWidgetAndTitle (variable) {
+    if (cluster.isWorker) process.send({ type: 'widget_custom_variables', emit: 'refresh' })
+    else if (!_.isNil(global.widgets.custom_variables.socket)) global.widgets.custom_variables.socket.emit('refresh') // send update to widget
+
+    if (!_.isNil(variable)) {
+      const regexp = new RegExp(`\\${variable}`, 'ig')
+      let title = await global.cache.rawStatus()
+
+      if (title.match(regexp)) {
+        if (cluster.isWorker) process.send({ type: 'call', ns: 'api', fnc: 'setTitleAndGame', args: { 0: null } })
+        else global.api.setTitleAndGame(global.api, null)
+      }
+    }
+  }
+}
+
+module.exports = CustomVariables

--- a/libs/message.js
+++ b/libs/message.js
@@ -124,46 +124,29 @@ class Message {
       }
     }
     let custom = {
-      '$_#': async (filter) => {
-        let variable = filter.replace('$_', '')
+      '$_#': async (variable) => {
         let isMod = await global.commons.isMod(attr.sender)
         if ((global.commons.isOwner(attr.sender) || isMod) &&
-          (!_.isUndefined(attr.param) && attr.param.length !== 0)) {
-          if (attr.param === '+' || attr.param === '-') {
-            let cvar = await global.db.engine.findOne('customvars', { key: variable })
-            if (attr.param === '+') attr.param = Number(cvar.value) + 1
-            else if (attr.param === '-') attr.param = Number(cvar.value) - 1
-            if (_.isNaN(attr.param)) attr.param = 0 // reset if not a number
+          (!_.isNil(attr.param) && attr.param.length !== 0)) {
+          let state = await global.customvariables.setValueOf(variable, attr.param, { sender: attr.sender })
+          if (state.isOk && !state.isEval) {
+            let msg = await global.commons.prepare('filters.setVariable', { value: state.updated.currentValue, variable: variable })
+            global.commons.sendMessage(msg, { username: attr.sender, skip: true, quiet: _.get(attr, 'quiet', false) })
           }
-
-          await global.db.engine.update('customvars', { key: variable }, { key: variable, value: attr.param })
-          let msg = await global.commons.prepare('filters.setVariable', { value: attr.param, variable: variable })
-          global.commons.sendMessage(msg, { username: attr.sender, quiet: _.get(attr, 'quiet', false) })
-
-          this.updateWidgetAndTitle(variable)
-          return ''
+          return state.isEval ? state.updated.currentValue : ''
         }
-        let cvar = await global.db.engine.findOne('customvars', { key: variable })
-        return _.isNil(cvar.value) ? '' : cvar.value
+        return global.customvariables.getValueOf(variable, { sender: attr.sender })
       },
       // force quiet variable set
-      '$!_#': async (filter) => {
-        let variable = filter.replace('$!_', '')
+      '$!_#': async (variable) => {
+        variable = variable.replace('$!_', '$_')
         let isMod = await global.commons.isMod(attr.sender)
         if ((global.commons.isOwner(attr.sender) || isMod) &&
-          (!_.isUndefined(attr.param) && attr.param.length !== 0)) {
-          if (attr.param === '+' || attr.param === '-') {
-            let cvar = await global.db.engine.findOne('customvars', { key: variable })
-            if (attr.param === '+') attr.param = cvar.value + 1
-            else if (attr.param === '-') attr.param = cvar.value - 1
-            if (_.isNaN(attr.param)) attr.param = 0 // reset if not a number
-          }
-          await global.db.engine.update('customvars', { key: variable }, { key: variable, value: attr.param })
-          this.updateWidgetAndTitle(variable)
-          return ''
+          (!_.isNil(attr.param) && attr.param.length !== 0)) {
+          let state = await global.customvariables.setValueOf(variable, attr.param, { sender: attr.sender })
+          return state.isEval ? state.updated.currentValue : ''
         }
-        let cvar = await global.db.engine.findOne('customvars', { key: variable })
-        return _.isNil(cvar.value) ? '' : cvar.value
+        return global.customvariables.getValueOf(variable, { sender: attr.sender })
       }
     }
     let param = {
@@ -625,14 +608,6 @@ class Message {
         }
       }
     }
-  }
-
-  async updateWidgetAndTitle (variable) {
-    if (require('cluster').isWorker) process.send({ type: 'widget_custom_variables', emit: 'refresh' })
-    else if (!_.isNil(global.widgets.custom_variables.io)) global.widgets.custom_variables.io.emit('refresh') // send update to widget
-    const regexp = new RegExp(`\\$_${variable}`, 'ig')
-    let title = await global.cache.rawStatus()
-    if (title.match(regexp)) process.send({ type: 'call', ns: 'api', fnc: 'setTitleAndGame', args: { 0: null } })
   }
 }
 

--- a/libs/overlays/text.js
+++ b/libs/overlays/text.js
@@ -17,10 +17,11 @@ class TextOverlay {
         let html = Buffer.from(b64string, 'base64').toString()
         let match = html.match(regexp)
         if (!_.isNil(match)) {
-          for (let variable of html.match(regexp).map((o) => o.replace('$_', ''))) {
-            let variableFromDB = await global.db.engine.findOne('customvars', { key: variable })
-            let value = _.isEmpty(variableFromDB.value) ? `<strong><i class="fas fa-dollar-sign">_${variable}</i></strong>` : variableFromDB.value
-            html = html.replace(new RegExp(`\\$_${variable}`, 'g'), value)
+          for (let variable of html.match(regexp)) {
+            let isVariable = await global.customvariables.isVariableSet(variable)
+            let value = `<strong><i class="fas fa-dollar-sign">_${variable.replace('$_', '')}</i></strong>`
+            if (isVariable) value = await global.customvariables.getValueOf(variable)
+            html = html.replace(new RegExp(`\\${variable}`, 'g'), value)
           }
         }
         html = await new Message(html).parse()

--- a/libs/panel.js
+++ b/libs/panel.js
@@ -77,6 +77,9 @@ function Panel () {
   app.get('/', this.authUser, function (req, res) {
     res.sendFile(path.join(__dirname, '..', 'public', 'index.html'))
   })
+  app.get('/:type/registry/:subtype/:page', this.authUser, function (req, res) {
+    res.sendFile(path.join(__dirname, '..', 'public', req.params.type, 'registry', req.params.subtype, req.params.page))
+  })
   app.get('/:type/:subtype/:page', this.authUser, function (req, res) {
     res.sendFile(path.join(__dirname, '..', 'public', req.params.type, req.params.subtype, req.params.page))
   })
@@ -169,9 +172,10 @@ function Panel () {
 
     // custom var
     socket.on('custom.variable.value', async (variable, cb) => {
-      let variableFromDb = await global.db.engine.findOne('customvars', { key: variable.replace('$_', '') })
-      if (_.isNil(variableFromDb.key)) cb(null, global.translate('webpanel.not-available'))
-      else cb(null, variableFromDb.value)
+      let value = global.translate('webpanel.not-available')
+      let isVariableSet = await global.customvariables.isVariableSet(variable)
+      if (isVariableSet) value = await global.customvariables.getValueOf(variable)
+      cb(null, value)
     })
 
     socket.on('responses.get', async function (at, callback) {

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -685,6 +685,7 @@
     "carousel": "Obrázky",
     "text": "Text",
     "manage": "Správa",
+    "registry": "Registr",
     "integrations": "Integrace",
     "ignorelist": "Ignore list",
     "settings": "Nastavení",

--- a/locales/cs/ui.commons.json
+++ b/locales/cs/ui.commons.json
@@ -1,0 +1,3 @@
+{
+  "never": "nikdy"
+}

--- a/locales/cs/ui.dialog.json
+++ b/locales/cs/ui.dialog.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "edit": "Upravit",
+    "add": "Přidat"
+  },
+  "buttons": {
+    "cancel": "Zrušit",
+    "close": "Zavřít",
+    "saveChanges": {
+      "idle": "Uložit změny",
+      "progress": "Ukládání změn",
+      "done": "Změny uloženy"
+    },
+    "something-went-wrong": "Něco se pokazilo",
+    "disable": "Vypnout",
+    "enable": "Zapnout",
+    "edit": "Upravit",
+    "delete": "Smazat",
+    "yes": "Ano",
+    "no": "Ne"
+  }
+}

--- a/locales/cs/ui.menu.json
+++ b/locales/cs/ui.menu.json
@@ -19,5 +19,7 @@
   "gallery": "Galerie médií",
   "games": "Hry",
   "spotify": "Spotify",
-  "integrations": "Integrace"
+  "integrations": "Integrace",
+  "custom-variables": "Vlastní proměnné",
+  "registry": "Registr"
 }

--- a/locales/cs/ui.registry.customvariables.json
+++ b/locales/cs/ui.registry.customvariables.json
@@ -1,0 +1,63 @@
+{
+  "isReadOnly": "v chatu pouze pro čtení",
+  "isNotReadOnly": "lze měnit prostřednictvím chatu",
+  "no-variables-found": "Nebyly nalezeny žádné proměnné",
+  "additional-info": "Doplňující informace",
+  "run-script": "Spustit skript",
+  "last-run": "Poslední spuštění v",
+  "variable": {
+    "name": "Název proměnné",
+    "help": "Název proměnné musí být jedinečný, například $_wins, $_loses, $_top3",
+    "placeholder": "Zadejte jedinečný název proměnné",
+    "error": {
+      "isNotUnique": "Proměnná musí mít <strong>jedinečný</strong> název.",
+      "isEmpty": "Název proměnné nesmí být prázdný."
+    }
+  },
+  "description": {
+    "name": "Popisek",
+    "help": "Volitelný popis",
+    "placeholder": "Zadejte volitelný popis"
+  },
+  "type": {
+    "name": "Typ",
+    "error": {
+      "isNotSelected": "Zvolte typ proměnné."
+    }
+  },
+  "currentValue": {
+    "name": "Aktuální hodnota",
+    "help": "Pokud je typ nastaven na <strong>skript</strong>, nelze hodnotu změnit ručně"
+  },
+  "usableOptions": {
+    "name": "Použitelné možnosti",
+    "placeholder": "Zadejte, své, možnosti, zde",
+    "help": "Možnosti, které lze použít s touto proměnnou, například <strong>SOLO, DUO, 3-SQ, SQUAD</strong>",
+    "error": {
+      "atLeastOneValue": "Musíte nastavit alespoň jednu hodnotu."
+    }
+  },
+  "scriptToEvaluate": "Skript, který chcete vyhodnotit",
+  "runScript": {
+    "name": "Spustit skript",
+    "error": {
+      "isNotSelected": "Prosím vyberte možnost."
+    }
+  },
+  "testCurrentScript": {
+    "name": "Otestovat aktuální skript",
+    "help": "Kliknutím na tlačítko <strong>Otestovat aktuální skript</strong> zobrazte hodnotu v poli <strong>Aktuální hodnota</strong>"
+  },
+  "warning": "<strong>Upozornění:</strong> Všechna data této proměnné budou smazána!",
+  "choose": "Vybrat...",
+  "types": {
+    "number": "Číslo",
+    "text": "Text",
+    "options": "Možnosti",
+    "eval": "Skript"
+  },
+  "runEvery": {
+    "isUsed": "Při použití proměnné",
+    "everyXMinutes": "Každých $minutes minut"
+  }
+}

--- a/locales/cs/ui.widgets.customvariables.json
+++ b/locales/cs/ui.widgets.customvariables.json
@@ -1,0 +1,5 @@
+{
+  "no-custom-variable-found": "Vlastní proměnné nenalezeny, přidejte je v <a href=\"/#registry/customVariables\">registru vlastních proměnných</a>",
+  "add-variable-into-watchlist": "Přidat proměnnou do seznamu sledování",
+  "watchlist": "Seznam sledování"
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -686,6 +686,7 @@
     "carousel": "Image Carousel",
     "text": "Text",
     "manage": "Manage",
+    "registry": "Registry",
     "ignorelist": "Ignore list",
     "settings": "Settings",
     "permissions": "Permissions",

--- a/locales/en/ui.commons.json
+++ b/locales/en/ui.commons.json
@@ -1,0 +1,3 @@
+{
+  "never": "never"
+}

--- a/locales/en/ui.dialog.json
+++ b/locales/en/ui.dialog.json
@@ -1,0 +1,22 @@
+{
+  "title": {
+    "edit": "Edit",
+    "add": "Add"
+  },
+  "buttons": {
+    "cancel": "Cancel",
+    "close": "Close",
+    "saveChanges": {
+      "idle": "Save changes",
+      "progress": "Saving changes",
+      "done": "Changes saved"
+    },
+    "something-went-wrong": "Something went wrong",
+    "disable": "Disable",
+    "enable": "Enable",
+    "edit": "Edit",
+    "delete": "Delete",
+    "yes": "Yes",
+    "no": "No"
+  }
+}

--- a/locales/en/ui.menu.json
+++ b/locales/en/ui.menu.json
@@ -19,5 +19,7 @@
   "gallery": "Media gallery",
   "games": "Games",
   "spotify": "Spotify",
-  "integrations": "Integrations"
+  "integrations": "Integrations",
+  "custom-variables": "Custom variables",
+  "registry": "Registry"
 }

--- a/locales/en/ui.registry.customvariables.json
+++ b/locales/en/ui.registry.customvariables.json
@@ -1,0 +1,64 @@
+{
+  "isReadOnly": "read-only in chat",
+  "isNotReadOnly": "can be changed through chat",
+  "no-variables-found": "No variables found",
+  "additional-info": "Additional info",
+  "run-script": "Run script",
+  "last-run": "Last run at",
+  "variable": {
+    "name": "Variable name",
+    "help": "Variable name must be unique, e.g. $_wins, $_loses, $_top3",
+    "placeholder": "Enter your unique variable name",
+    "error": {
+      "isNotUnique": "Variable must have <strong>unique</strong> name.",
+      "isEmpty": "Variable name must not be empty."
+    }
+  },
+  "description": {
+    "name": "Description",
+    "help": "Optional description",
+    "placeholder": "Enter your optional description"
+  },
+  "type": {
+    "name": "Type",
+    "error": {
+      "isNotSelected": "Please choose a variable type."
+    }
+  },
+  "currentValue": {
+    "name": "Current value",
+    "help": "If type is set to <strong>Evaluated script</strong>, value cannot be manually changed"
+  },
+  "usableOptions": {
+    "name": "Usable options",
+    "placeholder": "Enter, your, options, here",
+    "help": "Options, which can be used with this variable, example: <strong>SOLO, DUO, 3-SQ, SQUAD</strong>",
+    "error": {
+      "atLeastOneValue": "You need to set at least 1 value."
+    }
+  },
+  "scriptToEvaluate": "Script to evaluate",
+  "runScript": {
+    "name": "Run script",
+    "error": {
+      "isNotSelected": "Please choose an option."
+    }
+  },
+  "testCurrentScript": {
+    "name": "Test current script",
+    "help": "Click <strong>Test current script</strong> to see value in <strong>Current value</strong> input"
+  },
+  "warning": "<strong>Warning:</strong> All data of this variable will be discarded!",
+  "choose": "Choose...",
+  "types": {
+    "number": "Number",
+    "text": "Text",
+    "options": "Options",
+    "eval": "Script"
+  },
+  "runEvery": {
+    "isUsed": "When variable is used",
+    "everyXMinutes": "Every $minutes minutes"
+  }
+}
+

--- a/locales/en/ui.widgets.customvariables.json
+++ b/locales/en/ui.widgets.customvariables.json
@@ -1,0 +1,5 @@
+{
+  "no-custom-variable-found": "No custom variables found, add at <a href=\"/#registry/customVariables\">custom variables registry</a>",
+  "add-variable-into-watchlist": "Add variable to watchlist",
+  "watchlist": "Watchlist"
+}

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ function main () {
   global.logger = new (require('./libs/logging.js'))()
 
   global.events = new (require('./libs/events.js'))()
+  global.customvariables = new (require('./libs/customvariables.js'))()
 
   global.panel = new (require('./libs/panel'))()
   global.webhooks = new (require('./libs/webhooks'))()

--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
   <link rel="stylesheet" href="./dist/bootstrap-toggle/css/bootstrap-toggle.min.css" />
   <link rel="stylesheet" href="./dist/bootstrap-slider/css/bootstrap-slider.min.css" />
   <link rel="stylesheet" href="./dist/gridstack/css/gridstack.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/codemirror.min.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/addon/lint/lint.min.css" />
   <script src="/socket.io/socket.io.js"></script>
 </head>
 
@@ -69,6 +71,13 @@
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu" id="menu-settings"></ul>
+        </li>
+        <li class="nav-item dropdown">
+          <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+            <span data-lang="menu.registry"></span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" id="menu-registry"></ul>
         </li>
       </ul>
 
@@ -343,6 +352,18 @@
   <script type="text/javascript" src="/auth/token.js"></script>
   <script type="text/javascript" src="./dist/js/commons/commons.js"></script>
   <script src="/dist/velocity-animate/js/velocity.min.js"></script>
+  <!-- CodeMirror textarea editor -->
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/codemirror.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/mode/javascript/javascript.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/addon/edit/matchbrackets.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/addon/lint/javascript-lint.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.38.0/addon/lint/lint.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jshint/2.9.5/jshint.min.js"></script>
+
+  <!-- development version, includes helpful console warnings -->
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+  <!-- production version, optimized for size and speed --
+  <script src="https://cdn.jsdelivr.net/npm/vue"></script-->
 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.0-alpha14/js/tempusdominus-bootstrap-4.min.js"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.0-alpha14/css/tempusdominus-bootstrap-4.min.css" />
@@ -480,7 +501,6 @@
     })
 
     /* ROUTERS */
-    page.base('/')
     page('/', function(p){
       const id = p.hash.length === 0 ? 'dashboard' : p.hash
 
@@ -518,24 +538,27 @@
       var systems = false // we want only systems settings once
       var integrations = false // we want only systems settings once
       var overlays = false // we want only overlays settings once
+      var registry = false // we want only registry settings once
       _.each(menu, function (obj) {
         if (obj.id !== 'dashboard') {
           if ((obj.id === 'systems') && systems) return
           if ((obj.id === 'overlays') && overlays) return
           if ((obj.id === 'integrations') && integrations) return
+          if ((obj.id === 'registry') && registry) return
           $('#menu-' + obj.category).append('<li class="nav-item"><a class="nav-link" href="#" data-page="' +
-            obj.id + '" data-lang="menu.' + obj.name +
+            obj.id.replace(/\./g, '/') + '" data-lang="menu.' + obj.name +
             '"></a></li>')
         }
         if (obj.id === 'systems') systems = true
         if (obj.id === 'overlays') overlays = true
         if (obj.id === 'integrations') integrations = true
+        if (obj.id === 'registry') registry = true
       })
       loadedMenu = true
 
       $(".page-menu a,#menu-main a").on('click', function (ev) {
         ev.preventDefault()
-        if (!_.isNil(ev.currentTarget.dataset.page)) page('#' + ev.currentTarget.dataset.page)
+        if (!_.isNil(ev.currentTarget.dataset.page)) page('/#' + ev.currentTarget.dataset.page)
         $(".page-menu a,#menu-main a").removeClass('active')
         $(ev.currentTarget).addClass('active')
       })

--- a/public/pages/registry/customVariables.html
+++ b/public/pages/registry/customVariables.html
@@ -1,0 +1,99 @@
+<span data-lang="menu.custom-variables" class="title text-default"></span>
+<a class="btn btn-success float-right" href="/#registry/customVariables/edit" data-lang="dialog.title.add"></a>
+
+<div class="widget" id="customVariables-table">
+  <div class="alert alert-danger mb-0" role="alert" v-if="variables.length === 0">{{ commons.translate('registry.customvariables.no-variables-found') }}</div>
+  <table class="table table-striped" v-if="variables.length > 0">
+    <thead>
+      <tr>
+        <th scope="col" class="p-3">$_</th>
+        <th scope="col" class="p-3">{{ commons.translate('registry.customvariables.description.name') }}</th>
+        <th scope="col" class="p-3">{{ commons.translate('registry.customvariables.type.name') }}</th>
+        <th scope="col" class="p-3">{{ commons.translate('registry.customvariables.currentValue.name') }}</th>
+        <th scope="col" class="p-3">{{ commons.translate('registry.customvariables.additional-info') }}</th>
+        <th scope="col"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="variable of variables">
+        <td style="font-size: 1.2rem;">{{ variable.variableName }}</td>
+        <td v-bind:class="{ 'text-muted': variable.description.length === 0 }">
+          {{ variable.description.length !== 0 ? variable.description : commons.translate('not-available') }}
+        </td>
+        <td style="font-size: 1.2rem;">{{ commons.translate('registry.customvariables.types.' + variable.type) }}</td>
+        <td v-bind:class="{ 'text-muted': !variable.currentValue }">{{ variable.currentValue ? variable.currentValue : commons.translate('not-available') }}</td>
+        <td>
+          <span v-if="variable.type === 'eval'">
+            <div v-if="variable.runEvery">
+              <strong>{{ commons.translate('registry.customvariables.run-script') }}:</strong>
+              {{ commons.translate('registry.customvariables.runEvery.everyXMinutes').replace('$minutes', variable.runEvery / 60 / 1000) }}
+            </div>
+            <div>
+                {{ commons.translate('registry.customvariables.last-run') }} <strong>{{ variable.runAt ? new Date(variable.runAt).toLocaleString() : commons.translate('commons.never') }}</strong>
+            </div>
+          </span>
+          <span v-if="variable.type === 'options'">
+            <strong>{{ commons.translate('registry.customvariables.usableOptions.name') }}:</strong>
+            {{ variable.usableOptions }}
+          </span>
+          <div v-if="variable.readOnly">
+            <strong>{{ commons.translate('registry.customvariables.isReadOnly') | capitalize }}</strong>
+          </div>
+          <span v-else-if="!['eval', 'options'].includes(variable.type)" class="text-muted">{{ commons.translate('not-available') }}</span>
+        </td>
+        <td>
+          <a v-bind:href="'?id='+ variable._id + '#registry/customVariables/edit'" class="btn btn-primary btn-block"><i class="far fa-edit"></i> {{ commons.translate('dialog.buttons.edit') }}</a>
+          <button v-if="variable.type === 'eval'" v-on:click="debouncedRunScript(variable._id)" class="btn btn-secondary btn-block"><i class="fas fa-cog"></i> {{ commons.translate('registry.customvariables.run-script') }}</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<script>
+  Vue.prototype.commons = commons
+
+  function customVariablesInit () {
+    if (_.size(translations) === 0) return setTimeout(() => customVariablesInit(), 1)
+    var customVariablesTable = new Vue({
+      el: '#customVariables-table',
+      data: {
+        variables: {},
+
+        socket: io('/registry/customVariables', { query: "token=" + token }),
+      },
+      methods: {
+        runScript: function (id) {
+          this.socket.emit('run.script', id, (err, item) => {
+            // update variable data
+            let variable = this.variables.filter((o) => o._id === id)[0]
+            variable.currentValue = item.currentValue
+            variable.runAt = item.runAt
+          })
+        }
+      },
+      created: function () {
+        // _.debounce is a function provided by lodash to limit how
+        // often a particularly expensive operation can be run.
+        // In this case, we want to limit how often we access
+        // yesno.wtf/api, waiting until the user has completely
+        // finished typing before making the ajax request. To learn
+        // more about the _.debounce function (and its cousin
+        // _.throttle), visit: https://lodash.com/docs#debounce
+        this.debouncedRunScript =_.debounce(this.runScript, 1000)
+      },
+      filters: {
+        capitalize: function (value) {
+          if (!value) return ''
+          value = value.toString()
+          return value.charAt(0).toUpperCase() + value.slice(1)
+        }
+      }
+    })
+    customVariablesTable.socket.emit('list.variables', (err, data) => {
+      customVariablesTable.variables = data
+    })
+
+  }
+  customVariablesInit()
+</script>

--- a/public/pages/registry/customVariables/edit.html
+++ b/public/pages/registry/customVariables/edit.html
@@ -1,0 +1,350 @@
+<span id="customVariables-edit">
+  <span class="title text-default" style="padding: 0 !important;">
+    <a class="btn btn-outline-info" style="border: 0 !important;" href="/#registry/customVariables"><i class="fas fa-chevron-circle-left"></i></a>
+    <span style="position: relative; top: 2px;">{{ title }} </span>
+    <span style="position: relative; top: 2px;" v-if="isEditation">{{ variableName }}</span>
+  </span>
+
+  <span class="float-right">
+    <button v-if="saveState === 0" type="button" class="btn btn-primary" v-on:click="saveChanges()">{{ commons.translate('dialog.buttons.saveChanges.idle') }}</button>
+    <button v-if="saveState === 1" disabled="disabled" type="button" class="btn btn-info"><i class="fas fa-spinner fa-spin"></i> {{ commons.translate('dialog.buttons.saveChanges.progress') }}</button>
+    <button v-if="saveState === 2" disabled="disabled" type="button" class="btn btn-success"><i class="fas fa-check"></i> {{ commons.translate('dialog.buttons.saveChanges.done') }}</span></button>
+    <button v-if="saveState === 3" disabled="disabled" type="button" class="btn btn-danger"><i class="fas fa-exclamation"></i> {{ commons.translate('dialog.buttons.something-went-wrong') }}</span></button>
+  </span>
+
+  <div class="widget pt-3">
+    <!-- Editation stuff here -->
+    <form>
+        <div class="form-group col-md-12">
+          <label for="variable_name_input">{{ commons.translate('registry.customvariables.variable.name') }}</label>
+          <input v-bind:class="{ 'is-invalid': hasError.variableName || hasError.isNotUnique }" v-model="variableName" type="text" class="form-control" id="variable_name_input" v-bind:placeholder="commons.translate('registry.customvariables.variable.placeholder')">
+          <small class="form-text text-muted">{{ commons.translate('registry.customvariables.variable.help') }}</small>
+          <div class="invalid-feedback">
+            <span v-if="hasError.isNotUnique" v-html="commons.translate('registry.customvariables.variable.error.isNotUnique')"></span>
+            <span v-if="!hasError.isNotUnique">{{ commons.translate('registry.customvariables.variable.error.isEmpty') }}</span>
+          </div>
+        </div>
+
+        <div class="form-group col-md-12">
+          <label for="description_input">{{ commons.translate('registry.customvariables.description.name') }}</label>
+          <input v-model="description" type="text" class="form-control" id="description_input" v-bind:placeholder="commons.translate('registry.customvariables.description.placeholder')">
+          <small class="form-text text-muted">{{ commons.translate('registry.customvariables.description.help') }}</small>
+        </div>
+
+        <div class="form-group row pl-3 pr-3">
+          <div class="col-md-4">
+            <label for="type">{{ commons.translate('registry.customvariables.type.name') }}</label>
+            <select id="type" class="form-control" v-bind:class="{ 'is-invalid': hasError.selectedType }" v-model="selectedType">
+              <option value="" selected>{{ commons.translate('registry.customvariables.choose') }}</option>
+              <option v-for="type in types" v-bind:value="type.value">
+                {{ type.text }}
+              </option>
+            </select>
+            <div class="invalid-feedback">{{ commons.translate('registry.customvariables.type.error.isNotSelected') }}</div>
+          </div>
+
+          <div class="col-md-8">
+            <label for="current_value_input">{{ commons.translate('registry.customvariables.currentValue.name') }}</label>
+            <div class="input-group">
+              <input v-if="selectedType !== 'options'" v-model="currentValue" type="text" class="form-control" id="current_value_input" :readonly="(['', 'eval'].includes(selectedType)) ? true : false">
+              <select v-if="selectedType === 'options'" v-model="currentValue" class="form-control">
+                  <option v-for="option in usableOptionsArray">{{ option }}</option>
+              </select>
+
+              <div class="input-group-append" v-if="selectedType !== 'eval'">
+                <button  class="btn form-control" v-bind:class="{ 'btn-danger': readOnly, 'btn-success': !readOnly }" v-on:click="toggleReadOnly">
+                  <template v-if="readOnly">
+                    {{ commons.translate('registry.customvariables.isReadOnly') }}
+                  </template>
+                  <template v-else>
+                    {{ commons.translate('registry.customvariables.isNotReadOnly') }}
+                  </template>
+                </button>
+              </div>
+            </div>
+            <small class="form-text text-muted" v-html="commons.translate('registry.customvariables.currentValue.help')"></small>
+          </div>
+        </div>
+        <div class="form-group col-md-12" v-if="selectedType.toLowerCase() === 'options'">
+          <label for="usable_options_input">{{ commons.translate('registry.customvariables.usableOptions.name') }}</label>
+          <input v-bind:class="{ 'is-invalid': hasError.usableOptions }" v-model="usableOptions" type="text" class="form-control" id="usable_options_input" v-bind:placeholder="commons.translate('registry.customvariables.usableOptions.placeholder')">
+          <small class="form-text text-muted" v-html="commons.translate('registry.customvariables.usableOptions.help')"></small>
+          <div class="invalid-feedback">{{ commons.translate('registry.customvariables.usableOptions.error.atLeastOneValue') }}</div>
+        </div>
+
+        <div class="form-group row pl-3 pr-3" v-if="selectedType === 'eval'">
+          <div class="col-md-8">
+            <label for="variable_name_input">{{ commons.translate('registry.customvariables.scriptToEvaluate') }}</label>
+            <div id="custom_variables-textarea" class="border"></div>
+          </div>
+          <div class="col-md-4">
+            <label for="runEvery">{{ commons.translate('registry.customvariables.runScript.name') }}</label>
+            <select v-bind:class="{ 'is-invalid': hasError.selectedRunEvery }" id="runEvery" class="form-control" v-model="selectedRunEvery">
+              <option value="" selected>{{ commons.translate('registry.customvariables.choose') }}</option>
+              <option v-for="option in runEveryOptions" v-bind:value="option.value">
+                {{ option.text }}
+              </option>
+            </select>
+            <div class="invalid-feedback">{{ commons.translate('registry.customvariables.runScript.error.isNotSelected') }}</div>
+
+            <button type="button" class="btn btn-block btn-info mt-4" v-on:click="testScript()">{{ commons.translate('registry.customvariables.testCurrentScript.name') }}</button>
+            <small class="form-text text-muted" v-html="commons.translate('registry.customvariables.testCurrentScript.help')"></small>
+            <pre v-if="evalError.length > 0" class="alert alert-danger mt-2">{{ evalError }}</pre>
+
+          </div>
+        </div>
+      </form>
+
+      <div class="form-group col-md-12" v-if="isEditation">
+          <button type="button" class="btn btn-danger" key="deleting" data-lang="dialog.buttons.delete" v-if="deleteState === 'waiting'" v-on:click="deleteState='deleting'">{{ commons.translate('dialog.buttons.delete') }}</button>
+          <div class="btn-group" role="group" v-if="deleteState === 'deleting'">
+            <button type="button" class="btn btn-danger" key="deleted" data-lang="dialog.buttons.yes" v-on:click="deleteState='deleted'">{{ commons.translate('dialog.buttons.yes') }}</button>
+            <button type="button" class="btn btn-success" key="waiting" data-lang="dialog.buttons.no" v-on:click="deleteState='waiting'">{{ commons.translate('dialog.buttons.no') }}</button>
+          </div>
+          <small class="form-text text-danger" v-html="commons.translate('registry.customvariables.warning')"></small>
+        </div>
+    <!-- -->
+  </div>
+</span>
+
+<script>
+  Vue.prototype.commons = commons
+
+  function customVariablesEditInit () {
+    if (_.size(translations) === 0) return setTimeout(() => customVariablesEditInit(), 1)
+
+    var customVariablesEdit = new Vue({
+      el: '#customVariables-edit',
+      data: {
+        types: [
+          {
+              value: 'number',
+              text: commons.translate('registry.customvariables.types.number')
+          },
+          {
+            value: 'text',
+            text: commons.translate('registry.customvariables.types.text')
+          },
+          {
+            value: 'options',
+            text: commons.translate('registry.customvariables.types.options')
+          },
+          {
+            value: 'eval',
+            text: commons.translate('registry.customvariables.types.eval')
+          }
+        ],
+        runEveryOptions: [
+          {
+            value: 0,
+            text: commons.translate('registry.customvariables.runEvery.isUsed')
+          },
+          {
+            value: 1000 * 60 * 5,
+            text: commons.translate('registry.customvariables.runEvery.everyXMinutes').replace('$minutes', 5)
+          },
+          {
+            value: 1000 * 60 * 15,
+            text: commons.translate('registry.customvariables.runEvery.everyXMinutes').replace('$minutes', 15)
+          },
+          {
+            value: 1000 * 60 * 30,
+            text: commons.translate('registry.customvariables.runEvery.everyXMinutes').replace('$minutes', 30)
+          },
+          {
+            value: 1000 * 60 * 60,
+            text: commons.translate('registry.customvariables.runEvery.everyXMinutes').replace('$minutes', 60)
+          }
+        ],
+        selectedType: '',
+        selectedRunEvery: '',
+        deleteState: 'waiting',
+
+        variableNameInitial: '',
+        variableName: '',
+        description: '',
+        currentValue: '',
+        usableOptions: '',
+        readOnly: false,
+
+        evalValueInit: '',
+        evalInput: null,
+        evalError: '',
+
+        hasError: {
+          variableName: false,
+          selectedType: false,
+          usableOptions: false,
+          isNotUnique: false
+        },
+
+        socket: io('/registry/customVariables', { query: "token=" + token }),
+
+        saveState: 0
+      },
+      methods: {
+        toggleReadOnly: function (event) {
+          if (event) event.preventDefault()
+          this.readOnly = !this.readOnly
+        },
+        testScript: function () {
+          this.socket.emit('test.script', this.evalValue, (err, response) => {
+            if (err) {
+              this.evalError = err
+              this.evalOk = false
+            } else {
+              this.evalError = ''
+              this.evalOk = true
+            }
+            this.currentValue = response
+          })
+        },
+        validateForm: function () {
+          // reset errors
+          for (let [key, value] of Object.entries(this.hasError)) {
+            if (key !== 'isNotUnique') {
+              this.hasError[key] = false
+            }
+          }
+          if (this.variableName.length === 0 || (this.variableName.length === 2 && this.variableName.startsWith('$_'))) this.hasError.variableName = true
+
+          if (this.selectedType === '') this.hasError.selectedType = true
+          else if (this.selectedType === 'number') {
+            if (_.isNaN(Number(this.currentValue))) this.currentValue = 0
+            else this.currentValue = Number(this.currentValue) // retype
+          } else if (this.selectedType === 'options') {
+            // check options
+            if (this.usableOptionsArray.length === 0) {
+              this.hasError.usableOptions = true
+            }
+            // if current value is not set or is not set as option -> force first item
+            if (String(this.currentValue).trim().length === 0 || !this.usableOptionsArray.includes(String(this.currentValue).trim())) this.currentValue = this.usableOptionsArray[0]
+          } else if (this.selectedType === 'eval') {
+            if (this.selectedRunEvery === '') this.hasError.selectedRunEvery = true
+          }
+
+          return _.filter(this.hasError, (o) => o === true).length === 0
+        },
+        saveChanges: function () {
+          if (this.validateForm()) {
+            this.saveState = 1
+            const data = {
+              _id: commons.urlParam('id') ? commons.urlParam('id') : null,
+              variableName: this.variableName,
+              description: this.description,
+              currentValue: this.currentValue,
+              usableOptions: this.usableOptions,
+              evalValue: this.evalValue,
+              runEvery: this.selectedRunEvery,
+              type: this.selectedType,
+              readOnly: this.readOnly
+            }
+            this.socket.emit('save', data, (err, _id) => {
+              if (err) {
+                console.error(err)
+                return this.saveState = 3
+              }
+              this.saveState = 2
+
+              this.variableNameInitial = this.variableName
+              // if we are creating new -> refresh
+              if (_.isNil(data._id)) setTimeout(() => page(`?id=${_id}#registry/customVariables/edit`), 3000)
+            })
+          }
+        },
+        initializeEvalTextArea: function () {
+          const textarea = document.getElementById('custom_variables-textarea')
+          if (_.isNil(textarea)) return setTimeout(() => this.initializeEvalTextArea(), 1)
+
+          this.evalInput = CodeMirror(textarea, {
+            value: this.evalValueInit ? this.evalValueInit : "/* Available functions\n * url(link) - load data from API\n *\n * Available variables: _, users, random, sender (only in custom commands, keyword), param (only in custom command)\n *\n * IMPORTANT: Must contain return statement!\n */\n\nreturn '';",
+            mode:  "javascript",
+            lineNumbers: true,
+            matchBrackets: true,
+            lint: {
+              esversion: 6
+            },
+            gutters: ["CodeMirror-lint-markers"]
+          })
+        },
+        isUnique: function () {
+          if (this.variableName !== this.variableNameInitial) {
+            this.socket.emit('isUnique', this.variableName, (err, isUnique) => {
+              this.hasError.isNotUnique = !isUnique
+            })
+          }
+        }
+      },
+      created: function () {
+        // _.debounce is a function provided by lodash to limit how
+        // often a particularly expensive operation can be run.
+        // In this case, we want to limit how often we access
+        // yesno.wtf/api, waiting until the user has completely
+        // finished typing before making the ajax request. To learn
+        // more about the _.debounce function (and its cousin
+        // _.throttle), visit: https://lodash.com/docs#debounce
+        this.debouncedIsUnique =_.debounce(this.isUnique, 500)
+      },
+      watch: {
+        deleteState: function (cur, old) {
+          if (cur === 'deleted') {
+            this.socket.emit('delete', commons.urlParam('id'), () => {
+              page('/#registry/customVariables')
+            })
+          }
+        },
+        saveState: function (cur, old) {
+          if (cur === 2 || cur === 3) setTimeout(() => this.saveState = 0, 3000)
+        },
+        variableName: function (cur, old) {
+          if (!cur.startsWith('$_')) this.variableName = '$_' + cur
+          this.variableName = this.variableName.replace(/ /g, '_')
+          this.debouncedIsUnique()
+        },
+        selectedType: function (cur, old) {
+          if (cur === 'eval') {
+            this.initializeEvalTextArea()
+          } else if (cur === 'options') {
+            // check if value or change it
+            if (!this.usableOptionsArray.includes(this.currentValue)) this.currentValue = this.usableOptionsArray[0]
+          } else {
+            this.evalInput = null
+          }
+        },
+        usableOptionsArray: function (cur, old) {
+          this.currentValue = this.usableOptionsArray[0]
+        }
+      },
+      computed: {
+        evalValue: function () {
+          return !_.isNil(this.evalInput) ? this.evalInput.getValue() : ''
+        },
+        usableOptionsArray: function () {
+          return this.usableOptions.split(',').map((o) => o.trim()).filter((o) => o.length > 0)
+        },
+        isEditation: function () {
+          return !_.isNil(commons.urlParam('id'))
+        },
+        title: function () {
+          return commons.translate(this.isEditation ? 'dialog.title.edit' : 'dialog.title.add')
+        }
+      }
+    })
+
+    // load up from db
+    if (commons.urlParam('id')) {
+      customVariablesEdit.socket.emit('load', commons.urlParam('id'), (data) => {
+        customVariablesEdit.variableNameInitial = data.variableName
+        customVariablesEdit.variableName = data.variableName
+        customVariablesEdit.description = data.description
+        customVariablesEdit.currentValue = data.currentValue
+        customVariablesEdit.usableOptions = data.usableOptions
+        customVariablesEdit.evalValueInit = data.evalValue
+        customVariablesEdit.selectedRunEvery = data.runEvery
+        customVariablesEdit.selectedType = data.type
+        customVariablesEdit.readOnly = data.readOnly || false
+      })
+    }
+  }
+  customVariablesEditInit()
+</script>

--- a/public/widgets/bets.html
+++ b/public/widgets/bets.html
@@ -22,7 +22,7 @@
   <!-- Tab panes -->
   <div class="card-body">
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="bets-running">
+      <div role="tabpanel" class="tab-pane active" style="overflow:hidden;" id="bets-running">
         <canvas id="bets-container" class="p-2"></canvas>
       </div> <!-- /BETS -->
 

--- a/public/widgets/chat.html
+++ b/public/widgets/chat.html
@@ -28,7 +28,7 @@
       <div role="tabpanel" class="tab-pane active" id="chat-room-panel">
         <div id="chat-room" style="height: 100%"></div>
 
-        <form style="margin-top: -38px;">
+        <form style="margin-top: -40px;">
           <div class="form-row">
             <div class="col">
               <input type="text" id="chatInput" class="form-control" />

--- a/public/widgets/customvariables.html
+++ b/public/widgets/customvariables.html
@@ -1,4 +1,4 @@
-<div class="card widget">
+<div class="card widget" id="customVariablesWidget">
   <div class="card-header">
     <ul class="nav nav-pills" role="tablist">
       <li role="presentation" class="nav-item">
@@ -20,11 +20,79 @@
   <!-- Tab panes -->
   <div class="card-body">
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="customvariables-main"></div>
+      <div role="tabpanel" class="tab-pane active" id="customvariables-main">
+        <div v-for="(variable, index) of watchedVariables">
+          <div class="input-group" v-bind:class="{ 'pt-1': index != 0 }">
+            <div class="input-group-prepend">
+              <span class="input-group-text">{{ variable.variableName }}</span>
+            </div>
+            <template v-if="variable.type === 'text'">
+              <number-or-text
+                v-bind:id="String(variable._id)"
+                v-bind:value="variable.currentValue"
+                type="text"
+                v-on:update="onUpdate">
+              </number-or-text>
+            </template>
+            <template v-else-if="variable.type ==='eval'">
+              <input type="text" class="form-control" readonly v-bind:value="variable.currentValue">
+              <span class="input-group-text border-left-0"><i class="fas fa-code"></i></span>
+            </template>
+            <template v-else-if="variable.type ==='number'">
+              <number-or-text
+                v-bind:id="String(variable._id)"
+                v-bind:value="variable.currentValue"
+                type="number"
+                v-on:update="onUpdate">
+              </number-or-text>
+            </template>
+            <template v-else-if="variable.type ==='options'">
+              <div style="display: flex; flex: 1 1 auto;">
+                <div style="flex: 1 auto;" class="btn-group btn-group-toggle" data-toggle="buttons">
+                  <option-selector
+                    v-for="option of variable.usableOptions.split(',').map((o) => o.trim())"
+                    v-bind:value="option"
+                    v-bind:selected="variable.currentValue === option"
+                    v-on:update="onUpdate(String(variable._id), option)">
+                  </option-selector>
+                </div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </div>
       <!-- /MAIN -->
 
       <div role="tabpanel" class="tab-pane" id="customvariables-settings">
-        <div id="customvariables-watch"></div>
+        <span v-if="_.size(nonWatchedVariables) > 0">
+          <select class="form-control" v-model="selectedVariable">
+            <option v-bind:value="String(variable._id)" v-for="variable of nonWatchedVariables">{{ variable.variableName }}</option>
+          </select>
+          <button class="btn btn-block btn-primary" v-on:click="addToWatch(selectedVariable)">{{ commons.translate('widgets.customvariables.add-variable-into-watchlist') }}</button>
+        </span>
+        <span v-else>
+          <div class="alert alert-warning" v-html="commons.translate('widgets.customvariables.no-custom-variable-found')"></div>
+        </span>
+
+        <span v-if="watched.length > 0">
+          <h6 class="mt-2 mb-0">{{ commons.translate('widgets.customvariables.watchlist') }}</h6>
+          <ul class="list-group list-group-flush">
+            <li class="list-group-item" v-for="(watch, index) of watchedVariables">
+              <span class="row">
+                <div class="col-md-2 pt-2" style="line-height: 2rem;">
+                  <button v-if="index !== 0" class="btn btn-block btn-link col-md-2" v-on:click="moveUp(String(watch._id))"><i class="fas fa-angle-up"></i></button>
+                </div>
+                <div class="col-md p-2" style="overflow:hidden; line-height: 2rem;">
+                  {{ watch.variableName }}
+                  <button class="btn float-right btn-outline-danger border-0" v-on:click="unWatch(String(watch._id))"><i class="fas fa-trash-alt"></i></button>
+                </div>
+                <div class="col-md-2 pt-2" style="line-height: 2rem;">
+                  <button v-if="index !== watchedVariables.length - 1" class="btn btn-block btn-link col-md-2" v-on:click="moveDown(String(watch._id))"><i class="fas fa-angle-down"></i></button>
+                </div>
+              </span>
+            </li>
+          </ul>
+        </span>
       </div>
       <!-- /SETTINGS -->
     </div>
@@ -32,282 +100,168 @@
 </div>
 
 <script>
-var widgetsCustomVariablesSocket = io('/widgets/customVariables', { query: "token=" + token })
+Vue.prototype.commons = commons
 
-var customVariablesWidget = {
-  save: function (el) {
-    let name
-    if (!_.isNil(el.data)) {
-      name = el.name
-      value = el.value
-    } else {
-      name = $(el).data('name')
-      value = $(`input[data-name="${name}"]`).val()
+var optionsSelectorComponent = {
+  props: ['value', 'selected'], // data for component
+  methods: {
+    update: function () {
+      this.$emit('update')
     }
-
-    widgetsCustomVariablesSocket.emit('save.variable', { key: name, value: value }, () => {
-      $(`button.btn.btn-secondary[data-name="${name}"]`).css('display', 'none')
-    })
   },
-  increment: function (el) {
-    let name = $(el).data('name')
-    let value = $(`input[data-name="${name}"]`).val()
-    value = _.isFinite(parseInt(value, 10)) ? ++value : 0
-    $(`input[data-name="${name}"]`).val(value)
-    customVariablesWidget.save(el)
-  },
-  decrement: function (el) {
-    let name = $(el).data('name')
-    let value = $(`input[data-name="${name}"]`).val()
-    value = _.isFinite(parseInt(value, 10)) ? --value : 0
-    $(`input[data-name="${name}"]`).val(value)
-    customVariablesWidget.save(el)
-  },
-  saveValues: function (el) {
-    $(el).removeClass().addClass('btn btn-info')
-
-    let value = $(el).parents('.input-group').children('input').val()
-    widgetsCustomVariablesSocket.emit('save.values', {name: $(el).data('name'), value: value}, (err, cb) => {
-      if (err) return console.debug(err)
-
-      $(el).removeClass().addClass('btn btn-success')
-      customVariablesWidget.refresh()
-    })
-  },
-  generateLabels: function (values, current) {
-    current = current || null
-    values = values || _.get(translations, 'custom-variables.no-options-set', '{custom-variables.no-options-set}')
-    let out = ''
-    if (current && values.toLowerCase().indexOf(current.toLowerCase().trim()) === -1) {
-      out += `<label style="flex: 1 auto;" class="btn btn-secondary ${out.length === 0 ? 'active' : ''}">
-        <input type="radio" name="options" id="${current}" autocomplete="off" ${out.length === 0 ? 'checked' : ''}> ${current}
-      </label>`
-    }
-    for (value of values.split(',')) {
-      value = value.trim()
-      let isActive = (out.length === 0 && _.isNil(current)) || (current && value.toLowerCase().indexOf(current.toLowerCase().trim()) !== -1)
-      out += `<label style="flex: 1 auto;" class="btn btn-secondary ${isActive ? 'active' : ''}">
-        <input type="radio" name="options" id="${value}" autocomplete="off" ${isActive ? 'checked' : ''}> ${value}
-      </label>`
-    }
-    return out
-  },
-  watch: function (el) {
-    $(el).removeClass().addClass('btn btn-info')
-
-    let name = $('#customVariablesWidgetName input').val()
-    let type = $(el).parents('div.input-group').children('select').val()
-
-    $('#customVariablesWidgetName .form-control').removeClass('is-invalid')
-    $('#customVariablesWidgetName .invalid-tooltip').text()
-
-    console.debug({name: name, type: type})
-
-    widgetsCustomVariablesSocket.emit('watch', {name: name, type: type}, (err, cb) => {
-      if (err) {
-        $('#customVariablesWidgetName .invalid-tooltip').text(cb)
-        $('#customVariablesWidgetName .form-control').addClass('is-invalid')
-        $(el).removeClass().addClass('btn btn-primary')
-        return console.error(cb)
-      }
-      customVariablesWidget.refresh()
-    })
-  },
-  unwatch: function (el) {
-    $(el).removeClass().addClass('btn btn-info')
-    widgetsCustomVariablesSocket.emit('unwatch', $(el).data('name'), (err, cb) => {
-      if (err) return console.error(err)
-      $(`.input-group[data-variable-group='${cb}']`).velocity('fadeOut')
-      setTimeout(() => customVariablesWidget.refresh(), 500)
-    })
-  },
-  refresh: function () {
-    widgetsCustomVariablesSocket.emit('list.variables', (err, variables) => {
-      if (err) return console.error(err)
-      var i
-
-      // SET customvariables-main /////////////////////////////////////////////////
-      const main = $('#customvariables-main')
-      main.empty()
-
-      i = 0
-      for (let variable of variables) {
-        let variableEl = ''
-        switch(variable.type) {
-          case 'number':
-            variableEl = $(`
-              <div class="input-group" data-variable-group="${variable.name}" ${(i!==0) ? 'style="margin-top: 0.2rem"' : ''}>
-                <div class="input-group-prepend">
-                  <span class="input-group-text">$_${variable.name}</span>
-                </div>
-                <input type="text" class="form-control" data-custom-variable-input data-name="${variable.name}">
-
-                <div class="input-group-append">
-                  <button class="btn btn-secondary d-none" data-name="${variable.name}" onclick="customVariablesWidget.save(this)" type="button"><i class="fas fa-download"></i></button>
-                  <button class="btn btn-danger" data-name="${variable.name}" onclick="customVariablesWidget.decrement(this)" type="button"><i class="fas fa-minus"></i></button>
-                  <button class="btn btn-success" data-name="${variable.name}" onclick="customVariablesWidget.increment(this)" data-button="plus" type="button"><i class="fas fa-plus"></i></button>
-                </div>
-              </div>
-            `)
-            break
-          case 'text':
-            variableEl = $(`
-              <div class="input-group" data-variable-group="${variable.name}" ${(i!==0) ? 'style="margin-top: 0.2rem"' : ''}>
-                <div class="input-group-prepend">
-                  <span class="input-group-text">$_${variable.name}</span>
-                </div>
-                <input type="text" class="form-control" data-custom-variable-input data-name="${variable.name}">
-
-                <div class="input-group-append">
-                  <button class="btn btn-secondary d-none" data-name="${variable.name}" onclick="customVariablesWidget.save(this)" type="button"><i class="fas fa-download"></i></button>
-                </div>
-              </div>
-            `)
-            break
-          case 'options':
-            variableEl = $(`
-              <div class="input-group" data-variable-group="${variable.name}" ${(i!==0) ? 'style="margin-top: 0.2rem"' : ''}>
-                <div class="input-group-prepend">
-                  <span class="input-group-text">$_${variable.name}</span>
-                </div>
-
-                <div style="display: flex; flex: 1 1 auto;">
-                  <div style="flex: 1 auto;" class="btn-group btn-group-toggle" data-toggle="buttons">
-                    ${customVariablesWidget.generateLabels(variable.value)}
-                  </div>
-                </div>
-              </div>
-            `)
-            break
-        }
-        main.append(variableEl)
-        i++
-
-        // load variable custom value
-        widgetsCustomVariablesSocket.emit('load.variable', variable.name, (err, cb) => {
-          if (err) return console.error(err)
-          if (variable.type === 'number' || variable.type === 'text') {
-            $(`input[data-name="${cb.key}"]`).val(cb.value)
-          } else {
-            $(`[data-variable-group="${variable.name}"] div[data-toggle="buttons"]`).html(customVariablesWidget.generateLabels(variable.value, cb.value))
-          }
-        })
-      }
-      // set message if variables are empty
-      if (i === 0) {
-        main.append(`<div style="margin-left: 3.2rem" class="text-primary"><sup class="fas fa-caret-up"></sup> ${_.get(translations, 'custom-variables.set-your-variables-to-watch-here', '{custom-variables.set-your-variables-to-watch-here}')}</div>`)
-      }
-      // /SET customvariables-main ////////////////////////////////////////////////
-
-      // SET customvariables-watch ////////////////////////////////////////////////
-      const watch = $('#customvariables-watch')
-      watch.empty()
-
-      i = 0
-      for (let variable of variables) {
-        let watchEl = ''
-        switch(variable.type) {
-          case 'number':
-          case 'text':
-            watchEl = $(`
-              <div class="input-group" data-variable-group="${variable.name}" style="margin-bottom: 0.2rem">
-                <div class="input-group-prepend">
-                  <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">$_</span>
-                </div>
-                <input type="text" class="form-control" value="${variable.name}" disabled="disabled"/>
-                <div class="input-group-prepend">
-                  <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">${_.get(translations, 'custom-variables.type', '{custom-variables.type}')}</span>
-                </div>
-                <select class="form-control" disabled="disabled">
-                  <option>${variable.type}</option>
-                </select>
-                <div class="input-group-append">
-                  <button type="button" data-name="${variable.name}" onclick="customVariablesWidget.unwatch(this)" class="btn btn-danger">${_.get(translations, 'custom-variables.unwatch', '{custom-variables.unwatch}')}</button>
-                </div>
-              </div>
-            `)
-            break
-          case 'options':
-            watchEl = $(`
-            <div class="input-group" data-variable-group="${variable.name}">
-                <div class="input-group-prepend">
-                  <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">$_</span>
-                </div>
-                <input type="text" class="form-control" value="${variable.name}" disabled="disabled">
-                <div class="input-group-prepend">
-                  <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">${_.get(translations, 'custom-variables.type', '{custom-variables.type}')}</span>
-                </div>
-                <select class="form-control" disabled="disabled">
-                  <option>${_.get(translations, 'custom-variables.options', '{custom-variables.options}')}</option>
-                </select>
-                <div class="input-group-append">
-                  <button type="button" data-name="${variable.name}" onclick="customVariablesWidget.unwatch(this)" class="btn btn-danger">${_.get(translations, 'custom-variables.unwatch', '{custom-variables.unwatch}')}</button>
-                </div>
-              </div>
-
-              <div class="input-group" data-variable-group="${variable.name}" style="margin-top: -1px; margin-bottom: 0.2rem">
-                <div class="input-group-prepend">
-                  <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">${_.get(translations, 'custom-variables.options', '{custom-variables.options}')}</span>
-                </div>
-                <input type="text" class="form-control" data-custom-variable-input data-name="${variable.name}" placeholder="${_.get(translations, 'custom-variables.options-placeholder', '{custom-variables.options-placeholder}')}" value="${variable.value ? variable.value : ''}">
-                <div class="input-group-append" style="margin-top:1px;">
-                  <button class="btn btn-secondary d-none" type="button" data-name="${variable.name}" onclick="customVariablesWidget.saveValues(this)"><i class="fas fa-download"></i></button>
-                </div>
-              </div>
-            `)
-            break
-        }
-        watch.append(watchEl)
-      }
-      watch.append(`
-        <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">$_</span>
-          </div>
-          <div id="customVariablesWidgetName" style="flex: 1 1 auto; width: 5%">
-            <input type="text" class="form-control">
-            <div class="invalid-tooltip"></div>
-          </div>
-          <div class="input-group-prepend">
-            <span class="input-group-text" style="border-left: 0; font-weight: bold; font-variant: small-caps">${_.get(translations, 'custom-variables.type', '{custom-variables.type}')}</span>
-          </div>
-          <select class="form-control">
-            <option value="number">${_.get(translations, 'custom-variables.number', '{custom-variables.number}')}</option>
-            <option value="text">${_.get(translations, 'custom-variables.text', '{custom-variables.text}')}</option>
-            <option value="options">${_.get(translations, 'custom-variables.options', '{custom-variables.options}')}</option>
-          </select>
-          <div class="input-group-append">
-            <button type="button" class="btn btn-primary" onclick="customVariablesWidget.watch(this)">${_.get(translations, 'custom-variables.watch', '{custom-variables.watch}')}</button>
-          </div>
-        </div>
-      `)
-      // /SET customvariables-watch ///////////////////////////////////////////////
-    })
-  }
+  template: `
+    <label style="flex: 1 auto;" class="btn btn-secondary" v-bind:class="{ active : selected }" v-on:click="update()">
+      <input type="radio" name="options" v-bind:id="value" autocomplete="off" checked="">{{ value }}
+    </label>`
 }
 
-$(document).on('click', `[data-variable-group] div[data-toggle="buttons"] label`, (event) => {
-  let name = $(event.currentTarget).parents('[data-variable-group]').data('variable-group')
-  let value = $(event.currentTarget).children('input').attr('id')
-  console.debug(name, value)
-  customVariablesWidget.save({ name: name, value: value, data: true })
-})
+var numberOrTextComponent = {
+  props: ['id', 'value', 'type'],
+  watch: {
+    value: function (val) {
+      this.currentValue = this.value
+    },
+    currentValue: function (val, old) {
+      this.showSaveButton = this.initialValue != this.currentValue
+    }
+  },
+  methods: {
+    update: function (val) {
+      if (val) this.currentValue = Number(this.currentValue) + Number(val)
+      else if (this.type === 'number') this.currentValue = Number(this.currentValue)
+      if (_.isNaN(this.currentValue)) this.currentValue = 0
 
-$(document).on('keydown', '[data-custom-variable-input]', (event) => {
-  let name = $(event.currentTarget).data('name')
+      this.initialValue = this.currentValue
+      this.showSaveButton = false
 
-  if (event.which == 13) { // enter to save
-    $(`button.btn.btn-secondary[data-name="${name}"]`).trigger('click')
-    $(event.currentTarget).blur()
-  } else {
-    $(`button.btn.btn-secondary[data-name="${name}"]`).removeClass('d-none')
-    $(`button.btn.btn-secondary[data-name="${name}"]`).css('display', 'inline-block')
-  }
-})
+      this.$emit('update', this.id, this.currentValue)
+    },
+    onKeyUp: function (event) {
+      if (event.key === 'Enter') this.update()
+    }
+  },
+  data: function () {
+    return {
+      showSaveButton: false,
+      currentValue: this.value
+    }
+  },
+  created: function () {
+    this.initialValue = this.value
+  },
+  computed: {
+    typeTemplate: function () {
+      if (this.type === 'number') return '<strong>0-9</strong>'
+      else return '<i class="fas fa-font"></i>'
+    }
+  },
+  template: `
+    <div class="form-control p-0 d-flex border-0">
+      <input type="text" class="form-control" v-model="currentValue" style="z-index:99" v-on:keyup="onKeyUp">
+      <div class="input-group-append">
+        <button class="btn btn-primary" v-bind:class="{'d-none' : type !== 'number'}" type="button" v-on:click="update(1)"><i class="fas fa-plus"></i></button>
+        <button class="btn btn-danger" v-bind:class="{'d-none' : type !== 'number'}" type="button" v-on:click="update(-1)"><i class="fas fa-minus"></i></button>
+        <button class="btn btn-secondary" v-bind:class="{'d-none' : !showSaveButton}" type="button" v-on:click="update()"><i class="fas fa-download"></i></button>
+        <span class="input-group-text" v-html="typeTemplate"></span>
+      </div>
+    </div>
+    `
+}
 
-customVariablesWidget.refresh()
 
-widgetsCustomVariablesSocket.off('refresh').on('refresh', () => {
-  customVariablesWidget.refresh()
-})
+function customVariablesWidgetInit () {
+  if (_.size(translations) === 0) return setTimeout(() => customVariablesWidgetInit(), 1)
+  var customVariablesWidget = new Vue({
+    el: '#customVariablesWidget',
+    components: {
+      'option-selector': optionsSelectorComponent,
+      'number-or-text': numberOrTextComponent
+    },
+    data: {
+      variables: [],
+      watched: [],
+      selectedVariable: null,
+
+      socket: io('/widgets/customVariables', { query: "token=" + token }),
+    },
+    created: function () {
+      this.socket.on('refresh', () => {
+        this.refreshVariablesList()
+        this.refreshWatchList()
+      })
+      this.refreshVariablesList()
+      this.refreshWatchList()
+    },
+    computed: {
+      watchedVariables: function () {
+        let watched = []
+        for (let variable of this.variables) {
+          let filtered = this.watched.filter((o) => o.variableId === String(variable._id))
+          if (filtered.length !== 0) {
+            variable.order = filtered[0].order
+            watched.push(variable)
+          }
+        }
+        return _.orderBy(watched, 'order', 'asc')
+      },
+      nonWatchedVariables: function () {
+        let nonWatched = []
+        for (let variable of this.variables) {
+          let filtered = this.watched.filter((o) => o.variableId === String(variable._id))
+          if (filtered.length === 0) nonWatched.push(variable)
+        }
+        return nonWatched
+      }
+    },
+    watch: {
+      nonWatchedVariables: function () {
+        if (!_.isNil(this.nonWatchedVariables[0])) this.selectedVariable = this.nonWatchedVariables[0]._id
+      }
+    },
+    methods: {
+      onUpdate: function (_id, value) {
+        this.socket.emit('set.value', { _id, value }, (err) => {
+          this.refreshVariablesList()
+          this.refreshWatchList()
+        })
+      },
+      moveUp: function (variableId) {
+        this.socket.emit('move.up', variableId, (err, variableId) => {
+          this.refreshWatchList()
+        })
+      },
+      moveDown: function (variableId) {
+        this.socket.emit('move.down', variableId, (err, variableId) => {
+          this.refreshWatchList()
+        })
+      },
+      addToWatch: function (variableId) {
+        if (!_.isNil(variableId)) {
+          this.socket.emit('add.watch', variableId, (err, variableId) => {
+            this.refreshWatchList()
+          })
+        }
+      },
+      unWatch: function (variableId) {
+        if (!_.isNil(variableId)) {
+          this.socket.emit('rm.watch', variableId, (err, variableId) => {
+            this.refreshWatchList()
+          })
+        }
+      },
+      refreshVariablesList: function () {
+        this.socket.emit('list.variables', (err, data) => {
+          this.variables = data
+
+        })
+      },
+      refreshWatchList: function () {
+        this.socket.emit('list.watch', (err, data) => {
+          this.watched = data
+        })
+      }
+    }
+  })
+}
+customVariablesWidgetInit()
 </script>

--- a/public/widgets/twitch.html
+++ b/public/widgets/twitch.html
@@ -15,7 +15,7 @@
   <div class="card-body">
     <!-- Tab panes -->
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="twitch-main">
+      <div role="tabpanel" class="tab-pane active" style="overflow:hidden;" id="twitch-main">
       </div>
       <!-- /MAIN -->
     </div>

--- a/scss/custom.scss
+++ b/scss/custom.scss
@@ -1,3 +1,5 @@
+div.CodeMirror span.CodeMirror-matchingbracket {color: black !important; font-weight:bold;}
+
 // remove annoying button glow
 .btn:focus,.btn:active:focus,.btn.active:focus,
 .btn.focus,.btn:active.focus,.btn.active.focus {
@@ -66,6 +68,7 @@ a.active {
 /* STREAM DASHBOARD INFORMATIONS */
 .stream-info-container {
   background: $info-bg;
+  overflow: hidden;
   padding: 10px;
   border-bottom: 1px solid $gray-500;
 }
@@ -232,7 +235,7 @@ a.active {
 }
 
 .widget {
-  overflow: hidden;
+  overflow-x: hidden;
   color: $gray-700;
   background: $card-bg;
   padding: 0;
@@ -243,12 +246,14 @@ a.active {
 
 .widget .card-header {
   padding: 0;
+  height: 40px;
 }
 
 .widget .card-body {
   padding: 0;
   height: 100%;
-  padding-bottom: 40px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .widget .card-body .card-title {
@@ -272,7 +277,6 @@ span.title {
   display: inline-block;
   font-size: 26px !important;
   font-weight: bold !important;
-  text-transform: uppercase;
   border: 0 !important;
   padding:0 10px !important;
   margin-bottom: 0;
@@ -357,6 +361,7 @@ span.title.title-part.text-default + div.widget {
 
 .widget .tab-content, .widget .tab-pane.active {
   height: 100%;
+  padding: 0.2rem;
 }
 
 .widget .table tr:first-child > td {
@@ -405,6 +410,10 @@ span.title.title-part.text-default + div.widget {
  .chat-block {
    padding-left: 10px; padding-right: 10px;
  }
+
+#chat-room {
+  padding-bottom: 5px;
+}
 
 #chat-room iframe {
   height: 100%;


### PR DESCRIPTION
###### FEATURES & DESCRIPTION
- [X] Custom variables registry to set variables
- [x] New variable types: eval, number, text, options 
- [x] Update widget to watch variables from registry
- [x] Update `$!_#` and `$_`# message filters
- [x] Add readonly toggle for change through chat

###### Note
No migration for custom variables

###### ISSUES TO FIX
- [x] If variables are added in registry, widget should not need refresh
- [x] If variable is deleted in registry, watch variable should be removed
- [x] Add sender variable for eval if used in keyword or custom command, otherwise null
- [x] `Not Available` additional info should not be shown when there is at least one item (like readonly)
- [x] Add sender and param to eval
- [x] Add delete of variables from watchlist

###### ISSUES REFS

###### CHECKLIST
- [x] Added tests _if applicable_
- [x] Add test for read only variables
- [x] Translations added
- [x] Commits Squashed
- [x] Test Passing
