### PR TITLE
oauth: disable reconnect on undefined channelid

### DIFF
--- a/src/bot/oauth.js
+++ b/src/bot/oauth.js
@@ -129,10 +129,12 @@ class OAuth extends Core {
     if (this.currentChannel !== channel && channel !== '') {
       this.currentChannel = channel
       const cid = await global.users.getIdFromTwitch(channel)
-      this.settings._.channelId = cid
-      global.log.info('Channel ID set to ' + cid)
-      global.tmi.reconnect('bot')
-      global.tmi.reconnect('broadcaster')
+      if (typeof cid !== 'undefined') {
+        this.settings._.channelId = cid
+        global.log.info('Channel ID set to ' + cid)
+        global.tmi.reconnect('bot')
+        global.tmi.reconnect('broadcaster')
+      }
     }
 
     this.timeouts['getChannelId'] = setTimeout(() => this.getChannelId(), 10000)


### PR DESCRIPTION
Prevents connection to undefined channelId, which may cause some
future issues with connections (would not reconnect if channelId
is changed)

###### FEATURES & DESCRIPTION
- [ ] Feature 1
  - feature description

###### ISSUES REFS

###### CHECKLIST
- [ ] Added tests _if applicable_
- [ ] Docs Updated _if applicable_
- [ ] Translations added
- [ ] Commits Squashed
