### PR TITLE
commons: fix timeouting when broadcaster oauth is not set

### DIFF
--- a/src/bot/commons.js
+++ b/src/bot/commons.js
@@ -169,7 +169,7 @@ Commons.prototype.message = async function (type, username, message, retry) {
 }
 
 Commons.prototype.timeout = async function (username, reason, timeout) {
-  if (cluster.isMaster) global.tmi.client.bot.chat.timeout(global.commons.getBroadcaster(), username, timeout, reason)
+  if (cluster.isMaster) global.tmi.client.bot.chat.timeout(global.oauth.settings.general.channel, username, timeout, reason)
   else if (process.send) process.send({ type: 'timeout', username: username, timeout: timeout, reason: reason })
 }
 


### PR DESCRIPTION
Fixes #1500

###### CHECKLIST
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
