### PR TITLE
 api: update subscribers endpoint to helix

### DIFF
--- a/src/bot/api.js
+++ b/src/bot/api.js
@@ -369,12 +369,8 @@ class API {
     return { state: true, opts }
   }
 
-  async getChannelSubscribers (opts) {
+  async getChannelSubscribers () {
     if (cluster.isWorker) throw new Error('API can run only on master')
-
-    opts = opts || {}
-    opts.subscribers = opts.subscribers || []
-    const subscribers = Array.from(opts.subscribers)
 
     const cid = global.oauth.channelId
     const url = `https://api.twitch.tv/helix/subscriptions?broadcaster_id=${cid}`

--- a/src/bot/oauth.js
+++ b/src/bot/oauth.js
@@ -31,9 +31,10 @@ class OAuth extends Core {
         refreshToken: '',
         username: '',
         scopes: [
-          'chat_login',
-          'channel_subscriptions',
-          'channel_check_subscription'
+          'chat:read',
+          'chat:edit',
+          'channel:moderate',
+          'channel:read:subscriptions',
         ],
         _authenticatedScopes: []
       },
@@ -79,7 +80,7 @@ class OAuth extends Core {
         },
         generate: {
           type: 'link',
-          href: 'https://twitchtokengenerator.com/quick/Wwv9XnaPVM',
+          href: 'https://twitchtokengenerator.com/quick/RkshHUnw16',
           class: 'btn btn-primary btn-block',
           text: 'commons.generate',
           target: '_blank'


### PR DESCRIPTION
Fixes #1823

This will update subscriber endpoint from kraken to new helix. Broadcasters account oauth **needs** to be updated to be able to use new endpoint.

**New broadcaster scopes:** 
- chat:read
- chat:edit
- channel:moderate
- channel:read:subscriptions

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
