### PR TITLE
fix: throw warning message if non retroactive object is used

### DIFF
--- a/docs/_master/howto/write-own-system.md
+++ b/docs/_master/howto/write-own-system.md
@@ -95,19 +95,32 @@ const options: InterfaceSettings = {
 ```
 
 #### Others
-You can set your own settings variables. Only `number`, `boolean` and `string` is supported.
+
+You can set your own settings variables. Only `number`, `boolean` and `string`
+is supported. You can also add category for your settings. Use **null** value
+if you dont want to have type check.
 
 ##### Configurable in UI
+
 ``` javascript
 const settings = {
   // ...
   mySettingValueNum: 1,
   mySettingValueBool: true,
   mySettingValueString: 'Lorem Ipsum',
+  mySettingWithoutTypeCheck: null,
+  mySettingsCategory: {
+    valueNum: 1,
+    valueBool: false,
+    valueString: 'Lorem Ipsum',
+    WithoutTypeCheck: null,
+  }
   // ...
 }
 ```
+
 ##### Not configurable
+
 ``` javascript
 const settings = {
   // ...

--- a/src/bot/_interface.js
+++ b/src/bot/_interface.js
@@ -116,6 +116,10 @@ class Module {
           const path = key
           return new Proxy(target[key], {
             get: (target, key, receiver) => {
+              const isUnsupportedObject = typeof target[key] === 'object' && !Array.isArray(target[key]) && target[key] !== null
+              if (isUnsupportedObject) {
+                global.log.warning(`!!! ${this.constructor.name.toLowerCase()}.settings.${path}.${key} object is not retroactive, for advanced object types use database directly.`)
+              }
               if (key === 'then' || key === 'toJSON') return Reflect.get(target, key, receiver) // promisify
               if (_.isSymbol(key)) return undefined // handle iterator
               return target[key]


### PR DESCRIPTION
###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
