### PR TITLE
feat(twitch): add force game/title toggle

### DIFF
--- a/locales/cs/ui/core/twitch.json
+++ b/locales/cs/ui/core/twitch.json
@@ -1,0 +1,5 @@
+{
+  "settings": {
+    "isTitleForced": "Status/Hra je vynucena (bot přepíše jakékoliv změny odjinud)"
+  }
+}

--- a/locales/en/ui/core/twitch.json
+++ b/locales/en/ui/core/twitch.json
@@ -1,0 +1,5 @@
+{
+  "settings": {
+    "isTitleForced": "Title/Game is forced (bot will rewrite changes from elsewhere)"
+  }
+}

--- a/src/bot/api.js
+++ b/src/bot/api.js
@@ -579,7 +579,14 @@ class API {
           // check if status is same as updated status
           if (this.retries.getChannelDataOldAPI >= 15) {
             this.retries.getChannelDataOldAPI = 0
-            await global.cache.rawStatus(request.data.status)
+
+            // if we want title to be forced
+            if (global.twitch.isTitleForced) {
+              this.setTitleAndGame(null, {});
+              return { state: true, opts }
+            } else {
+              await global.cache.rawStatus(request.data.status);
+            }
           } else {
             this.retries.getChannelDataOldAPI++
             return { state: false, opts }

--- a/src/bot/twitch.js
+++ b/src/bot/twitch.js
@@ -8,7 +8,7 @@ const {
 const {
   getTime, sendMessage, prepare, getChannel
 } = require('./commons');
-import { command, default_permission } from './decorators';
+import { command, default_permission, settings } from './decorators';
 import { permission } from './permissions'
 import Core from './_interface';
 
@@ -18,6 +18,9 @@ const config = require('@config')
 config.timezone = config.timezone === 'system' || _.isNil(config.timezone) ? moment.tz.guess() : config.timezone
 
 class Twitch extends Core {
+  @settings('general')
+  isTitleForced = false;
+
   constructor () {
     super()
 


### PR DESCRIPTION
This toggle will ensure that bot will try to keep set games/title
forced (rewriting changes from other bots, dashboard)

Fixes #1714

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
