### PR TITLE
fix(ui): move dashboard out of frame

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -330,7 +330,6 @@
       if (currentPage === id.split('-')[0]) return
       else currentPage = id.split('-')[0]
       var visibility = id !== 'dashboard' ? 'none' : 'flex'
-      var visibilityBlock = id !== 'dashboard' ? 'none' : 'block'
 
       $("#pages-old").empty()
 
@@ -349,7 +348,8 @@
             }
           })
         }))
-      $(".widgets").css('display', visibilityBlock)
+      $(".widgets").css('top', id !== 'dashboard' ? '-99999px' : '')
+      $(".widgets").css('position', id !== 'dashboard' ? 'absolute' : 'inherit')
     })
     page({ popstate:true })
 


### PR DESCRIPTION
Chrome is causing bug, where
invisible (display or visibility) YT player
does not trigger play. Workaround
is to move whole dashboard out of visible
frame

Fixes #2410

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
