### PR TITLE
fix(ui): skip null filter on _permissions

### DIFF
--- a/src/panel/views/settings/interface.vue
+++ b/src/panel/views/settings/interface.vue
@@ -430,11 +430,14 @@ export default class interfaceSettings extends Vue {
         console.debug({ui, settings});
 
         for (const k of Object.keys(settings)) {
-          settings[k] = _.pickBy(settings[k], (value) => {
-            return value !== null;
-          });
-          if (Object.keys(settings[k]).length === 0) {
-            delete settings[k]
+          // dont update _permissions as they might be null
+          if (k !== '_permissions') {
+            settings[k] = _.pickBy(settings[k], (value) => {
+              return value !== null;
+            });
+            if (Object.keys(settings[k]).length === 0) {
+              delete settings[k]
+            }
           }
         };
         console.debug({ui, settings});


### PR DESCRIPTION
_permissions can be null as it means disabled

Fixes #2547

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
