### PR TITLE
fix(ui): keep ordered settings without lose of initial data

### DIFF
--- a/src/panel/views/settings/interface.vue
+++ b/src/panel/views/settings/interface.vue
@@ -292,24 +292,24 @@ export default class interfaceSettings extends Vue {
     // set settings as first and commands as last
     const settings = withoutPermissions.settings; delete withoutPermissions.settings;
     const commands = withoutPermissions.commands; delete withoutPermissions.commands;
-    const ordered = {};
+    let ordered = {};
     Object.keys(withoutPermissions).sort().forEach(function(key) {
       ordered[key] = withoutPermissions[key];
     });
     if (settings) {
-      withoutPermissions = {
+      ordered = {
         settings,
         ...ordered,
       }
     }
     if (commands) {
-      withoutPermissions = {
+      ordered = {
         ...ordered,
         commands,
       }
     }
-    console.log({withoutPermissions})
-    return withoutPermissions
+    console.log({ordered})
+    return ordered
   }
 
   mounted() {


### PR DESCRIPTION
Fixes #2555

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
