### PR TITLE
fix(commands): run similar commands only if expecting $param

### DIFF
--- a/src/bot/systems/customCommands.ts
+++ b/src/bot/systems/customCommands.ts
@@ -262,7 +262,7 @@ class CustomCommands extends System {
     } // do nothing if it is not a command
     const _responses: Response[] = [];
     const commands: {
-      command: any
+      command: any;
       cmdArray: string[];
     }[] = [];
     const cmdArray = opts.message.toLowerCase().split(' ');

--- a/src/bot/systems/customCommands.ts
+++ b/src/bot/systems/customCommands.ts
@@ -261,36 +261,47 @@ class CustomCommands extends System {
       return true;
     } // do nothing if it is not a command
     const _responses: Response[] = [];
-    let command: any = {};
+    const commands: {
+      command: any
+      cmdArray: string[];
+    }[] = [];
     const cmdArray = opts.message.toLowerCase().split(' ');
     for (let i = 0, len = opts.message.toLowerCase().split(' ').length; i < len; i++) {
-      command = await global.db.engine.findOne(this.collection.data, { command: cmdArray.join(' '), enabled: true });
-      if (!_.isEmpty(command)) {
-        break;
+      const db_commands = await global.db.engine.find(this.collection.data, { command: cmdArray.join(' '), enabled: true });
+      for (const command of db_commands) {
+        commands.push({
+          cmdArray: _.cloneDeep(cmdArray),
+          command,
+        });
       }
       cmdArray.pop(); // remove last array item if not found
     }
-    if (Object.keys(command).length === 0) {
+    if (commands.length === 0) {
       return true;
     } // no command was found - return
 
-    // remove found command from message to get param
-    const param = opts.message.replace(new RegExp('^(' + cmdArray.join(' ') + ')', 'i'), '').trim();
-    const count = await incrementCountOfCommandUsage(command.command);
-
-    const responses: Response[] = await global.db.engine.find(this.collection.responses, { cid: String(command._id) });
+    // go through all commands
     let atLeastOnePermissionOk = false;
-    for (const r of _.orderBy(responses, 'order', 'asc')) {
-      if ((await global.permissions.check(opts.sender.userId, r.permission)).access
-          && await this.checkFilter(opts, r.filter)) {
-        _responses.push(r);
-        atLeastOnePermissionOk = true;
-        if (r.stopIfExecuted) {
-          break;
+    for (const command of commands) {
+      // remove found command from message to get param
+      const param = opts.message.replace(new RegExp('^(' + command.cmdArray.join(' ') + ')', 'i'), '').trim();
+      const count = await incrementCountOfCommandUsage(command.command.command);
+      const responses: Response[] = await global.db.engine.find(this.collection.responses, { cid: String(command.command._id) });
+      for (const r of _.orderBy(responses, 'order', 'asc')) {
+        if ((await global.permissions.check(opts.sender.userId, r.permission)).access
+            && await this.checkFilter(opts, r.filter)) {
+          if (param.length > 0 && !r.response.includes('$param')) {
+            continue;
+          }
+          _responses.push(r);
+          atLeastOnePermissionOk = true;
+          if (r.stopIfExecuted) {
+            break;
+          }
         }
       }
+      this.sendResponse(_.cloneDeep(_responses), { param, sender: opts.sender, command: command.command.command, count });
     }
-    this.sendResponse(_.cloneDeep(_responses), { param, sender: opts.sender, command: command.command, count });
     return atLeastOnePermissionOk;
   }
 

--- a/test/tests/commands/run.js
+++ b/test/tests/commands/run.js
@@ -26,6 +26,34 @@ describe('Custom Commands - run()', () => {
     await global.db.engine.insert('users', { username: user1.username, id: user1.userId })
   })
 
+  describe.only('\'!test qwerty\' should trigger correct commands', () => {
+    it('create \'!test\' command with $param', async () => {
+      let cmd = await global.db.engine.insert('systems.customcommands', { command: '!test', enabled: true, visible: true })
+      await global.db.engine.insert('systems.customcommands.responses', { cid: String(cmd._id), filter: '', response: '$param by !test command with param', permission: permission.VIEWERS })
+    })
+    it('create \'!test\' command without $param', async () => {
+      let cmd = await global.db.engine.insert('systems.customcommands', { command: '!test', enabled: true, visible: true })
+      await global.db.engine.insert('systems.customcommands.responses', { cid: String(cmd._id), filter: '', response: 'This should not be triggered', permission: permission.VIEWERS })
+    })
+    it('create \'!test qwerty\' command without $param', async () => {
+      let cmd = await global.db.engine.insert('systems.customcommands', { command: '!test qwerty', enabled: true, visible: true })
+      await global.db.engine.insert('systems.customcommands.responses', { cid: String(cmd._id), filter: '', response: 'This should be triggered', permission: permission.VIEWERS })
+    })
+    it('create second \'!test qwerty\' command without $param', async () => {
+      let cmd = await global.db.engine.insert('systems.customcommands', { command: '!test qwerty', enabled: true, visible: true })
+      await global.db.engine.insert('systems.customcommands.responses', { cid: String(cmd._id), filter: '', response: 'This should be triggered as well', permission: permission.VIEWERS })
+    })
+
+    it('run command', async () => {
+      global.systems.customCommands.run({ sender: user1, message: '!test qwerty' })
+      await message.isSentRaw('This should be triggered', user1)
+      await message.isSentRaw('This should be triggered as well', user1)
+      await message.isSentRaw('qwerty by !test command with param', user1)
+      await message.isNotSentRaw('This should not be triggered', user1)
+    })
+
+  })
+
   describe('!cmd with username filter', () => {
     it('create command and response with filter', async () => {
       let cmd = await global.db.engine.insert('systems.customcommands', { command: '!cmd', enabled: true, visible: true })


### PR DESCRIPTION
Update behavior to run all custom commands which have similar names

e.g.
!test qwerty
---
!test with $param - OK
!test - NG
!test qwerty - OK

Fixes #2566

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
