### PR TITLE
fix(tmi): remove RITUAL handling

### DIFF
--- a/src/bot/tmi.js
+++ b/src/bot/tmi.js
@@ -344,49 +344,7 @@ class TMI extends Core {
       })
 
       this.client[type].chat.on('USERNOTICE', message => {
-        if (message.event === 'RAID') {
-          global.log.raid(`${message.parameters.login}, viewers: ${message.parameters.viewerCount}`)
-          global.db.engine.update('cache.raids', { username: message.parameters.login }, { username: message.parameters.login })
-
-          const data = {
-            username: message.parameters.login,
-            viewers: message.parameters.viewerCount,
-            type: 'raid'
-          }
-
-          global.overlays.eventlist.add(data)
-          global.events.fire('raid', data)
-          global.registries.alerts.trigger({
-              event: 'raids',
-              name: message.parameters.login,
-              amount: Number(message.parameters.viewerCount),
-              currency: '',
-              monthsName: '',
-              message: '',
-              autohost: false,
-            });
-
-        } else if (message.event === 'SUBSCRIPTION') {
-          this.subscription(message)
-        } else if (message.event === 'RESUBSCRIPTION') {
-          this.resub(message)
-        } else if (message.event === 'SUBSCRIPTION_GIFT') {
-          this.subgift(message)
-        } else if (message.event === 'SUBSCRIPTION_GIFT_COMMUNITY') {
-          this.subscriptionGiftCommunity(message)
-        } else if (message.event === 'RITUAL') {
-          if (message.parameters.ritualName === 'new_chatter') {
-            if (!global.users.newChattersList.includes(message.tags.username.toLowerCase())) {
-              global.users.newChattersList.push(message.tags.username.toLowerCase())
-              global.db.engine.increment('api.new', { key: 'chatters' }, { value: 1 })
-            }
-          } else {
-            global.log.info('Unknown RITUAL')
-          }
-        } else {
-          global.log.info('Unknown USERNOTICE')
-          global.log.info(JSON.stringify(message))
-        }
+        this.usernotice(message);
       })
 
       this.client[type].chat.on('NOTICE', message => {
@@ -423,6 +381,56 @@ class TMI extends Core {
       })
     } else {
       throw Error(`This ${type} is not supported`)
+    }
+  }
+
+  usernotice(message) {
+    if (message.event === 'RAID') {
+      global.log.raid(`${message.parameters.login}, viewers: ${message.parameters.viewerCount}`)
+      global.db.engine.update('cache.raids', { username: message.parameters.login }, { username: message.parameters.login })
+
+      const data = {
+        username: message.parameters.login,
+        viewers: message.parameters.viewerCount,
+        type: 'raid'
+      }
+
+      global.overlays.eventlist.add(data)
+      global.events.fire('raid', data)
+      global.registries.alerts.trigger({
+          event: 'raids',
+          name: message.parameters.login,
+          amount: Number(message.parameters.viewerCount),
+          currency: '',
+          monthsName: '',
+          message: '',
+          autohost: false,
+        });
+
+    } else if (message.event === 'SUBSCRIPTION') {
+      this.subscription(message)
+    } else if (message.event === 'RESUBSCRIPTION') {
+      this.resub(message)
+    } else if (message.event === 'SUBSCRIPTION_GIFT') {
+      this.subgift(message)
+    } else if (message.event === 'SUBSCRIPTION_GIFT_COMMUNITY') {
+      this.subscriptionGiftCommunity(message)
+    } else if (message.event === 'RITUAL') {
+      if (message.parameters.ritualName === 'new_chatter') {
+        /*
+        Workaround for https://github.com/sogehige/sogeBot/issues/2581
+        TODO: update for tmi-js
+        if (!global.users.newChattersList.includes(message.tags.login.toLowerCase())) {
+          global.users.newChattersList.push(message.tags.login.toLowerCase())
+          global.db.engine.increment('api.new', { key: 'chatters' }, { value: 1 })
+        }
+        */
+      } else {
+        global.log.info('Unknown RITUAL')
+      }
+    } else {
+      global.log.info('Unknown USERNOTICE')
+      global.log.info(JSON.stringify(message))
     }
   }
 


### PR DESCRIPTION
Removing handling of RITUAL doesn't make new chatter less useful,
we have backup code for new_chatter and determiting of new chatters.
This will need to be adressed when changed back to tmi.js

Closes #2581

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
