### PR TITLE
refactor(oauth): simplify error on token validate

### DIFF
--- a/src/bot/oauth.ts
+++ b/src/bot/oauth.ts
@@ -212,7 +212,7 @@ class OAuth extends Core {
         });
       } catch (e) {
         const errorMessage: string = e.data.data ? `${e.data.data.status} — ${e.data.data.message}` : `${e.response.status} — ${e.response.statusText}`;
-        error(`Error on validate ${type} OAuth token, error: ${errorMessage}`);
+        throw new Error(`Error on validate ${type} OAuth token, error: ${errorMessage}`);
       }
 
       this.clientId = request.data.client_id;

--- a/src/bot/oauth.ts
+++ b/src/bot/oauth.ts
@@ -211,9 +211,10 @@ class OAuth extends Core {
           },
         });
       } catch (e) {
-        const error = e.data.data ? e.data.data : `${e.response.status}: ${e.response.statusText}`;
-        error(`Error on validate ${type} OAuth token: ${error}`);
+        const errorMessage: string = e.data.data ? `${e.data.data.status} — ${e.data.data.message}` : `${e.response.status} — ${e.response.statusText}`;
+        error(`Error on validate ${type} OAuth token, error: ${errorMessage}`);
       }
+
       this.clientId = request.data.client_id;
 
       if (type === 'bot') {

--- a/src/bot/oauth.ts
+++ b/src/bot/oauth.ts
@@ -203,11 +203,17 @@ class OAuth extends Core {
         throw new Error(`Type ${type} is not supported`);
       }
 
-      const request = await axios.get(url, {
-        headers: {
-          Authorization: 'OAuth ' + this[type + 'AccessToken'],
-        },
-      });
+      let request;
+      try {
+        request = await axios.get(url, {
+          headers: {
+            Authorization: 'OAuth ' + this[type + 'AccessToken'],
+          },
+        });
+      } catch (e) {
+        const error = e.data.data ? e.data.data : `${e.response.status}: ${e.response.statusText}`;
+        error(`Error on validate ${type} OAuth token: ${error}`);
+      }
       this.clientId = request.data.client_id;
 
       if (type === 'bot') {


### PR DESCRIPTION
Right now error is very long.
![](https://cdn.satont.ru/s/FMnKZV.png)
I reworked it to:
If it was twitch exception, it will show data object, what is: `data: { status: 401, message: 'invalid access token' }`, for example. If it's http server error it will show status and statusText


###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
