### PR TITLE
refactor(socket): send admin/viewer errors if not access by default

### DIFF
--- a/src/bot/_interface.ts
+++ b/src/bot/_interface.ts
@@ -315,9 +315,6 @@ class Module {
           cb(null, true);
         }
       });
-      publicEndpoint(this.nsp, 'update', async (opts, cb) => {
-        cb('User doesn\'t have access to this endpoint', null);
-      });
       adminEndpoint(this.nsp, 'update', async (opts, cb) => {
         opts.collection = opts.collection || 'data';
         if (opts.collection.startsWith('_')) {

--- a/src/bot/socket.ts
+++ b/src/bot/socket.ts
@@ -145,6 +145,18 @@ class Socket extends Core {
     });
     emitAuthorize(socket);
 
+    for (const endpoint of endpoints.filter(o => (o.type === 'admin' || o.type === 'viewer') && o.nsp === socket.nsp.name)) {
+      socket.removeAllListeners(endpoint.on);
+      socket.on(endpoint.on, (...args) => {
+        // search for callback
+        for (const arg of args) {
+          if (typeof arg === 'function') {
+            arg('User doesn\'t have access to this endpoint', null);
+          }
+        }
+      });
+    }
+
     for (const endpoint of endpoints.filter(o => o.type === 'public' && o.nsp === socket.nsp.name)) {
       socket.removeAllListeners(endpoint.on);
       socket.on(endpoint.on, (...args) => {


### PR DESCRIPTION
Fixes #2886

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
