### PR TITLE
fix(sockets): split access/refresh token authorization

### DIFF
--- a/docs/_master/howto/connection-to-socket.md
+++ b/docs/_master/howto/connection-to-socket.md
@@ -9,13 +9,13 @@
 import io from 'socket.io-client';
 
 const namespace = "/"
-const socketToken = '<your-socket-token-here>';
+const token = '<your-socket-token-here>';
 
 const socket = io(namespace, { forceNew: true });
 
 // send correct token
 socket.on('authorize', (cb) => {
-  cb({socketToken})
+  cb({token, type: 'socket'});
 });
 
 socket.on('authorized', (cb) => {

--- a/src/bot/socket.ts
+++ b/src/bot/socket.ts
@@ -7,7 +7,7 @@ import { permission } from './helpers/permissions';
 import { adminEndpoint, endpoints } from './helpers/socket';
 import { onLoad } from './decorators/on';
 
-import { Brackets, getRepository, LessThanOrEqual } from 'typeorm';
+import { getRepository, LessThanOrEqual } from 'typeorm';
 import { Socket as SocketEntity } from './database/entity/socket';
 import permissions from './permissions';
 import { debug } from './helpers/log';
@@ -109,7 +109,7 @@ class Socket extends Core {
             auth = await getRepository(SocketEntity).findOne({ accessToken: cb.token });
             if (!auth) {
               debug('sockets', `Incorrect access token - ${cb.token}, asking for refresh token`);
-              return socket.emit('refreshToken', async (cb: { userId: number, token: string }) => {
+              return socket.emit('refreshToken', async (cb: { userId: number; token: string }) => {
                 auth = await getRepository(SocketEntity).findOne({ userId: cb.userId, refreshToken: cb.token });
                 if (!auth) {
                   debug('sockets', `Incorrect refresh token for userId - ${cb.token}, ${cb.userId}`);

--- a/src/panel/components/navbar/user.vue
+++ b/src/panel/components/navbar/user.vue
@@ -92,7 +92,7 @@ export default class User extends Vue {
     let status: string[] = [];
     for (const key of ['isFollower', 'isSubscriber', 'isVIP']) {
       if (this.viewer && this.viewer[key]) {
-        status.push(key);
+        status.push(key.replace('is', ''));
       }
     }
     return status;

--- a/src/panel/helpers/isUserLoggedIn.ts
+++ b/src/panel/helpers/isUserLoggedIn.ts
@@ -23,8 +23,10 @@ export const isUserLoggedIn = async function () {
       });
       const data = get(axiosData, 'data.data[0]', null);
       if (data === null) {
+        localStorage.removeItem('userId');
         throw Error('User must be logged');
       }
+      localStorage.setItem('userId', data.id);
 
       // set new authorization if set
       const newAuthorization = localStorage.getItem('newAuthorization');

--- a/src/panel/helpers/socket.ts
+++ b/src/panel/helpers/socket.ts
@@ -20,8 +20,8 @@ export function getSocket(namespace: string, continueOnUnauthorized = false) {
       const token = localStorage.getItem('refreshToken') || '';
       const userId = localStorage.getItem('userId') || 0;
       const type = 'refresh';
-      cb({token, type, userId})
-    })
+      cb({token, type, userId});
+    });
     socket.on('authorized', (cb) => {
       console.debug(`AUTHORIZED ACCESS(${cb.type}): ${namespace}`);
       localStorage.setItem('accessToken', cb.accessToken);


### PR DESCRIPTION
1. accessToken is sent to bot, if everything is OK, we have access
2. refreshToken with userId is sent after accessToken failed
3. user is unauthorized if steps above failed -> forced to login

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
