### PR TITLE
feat(customcommands): add $haveParam filter

### DIFF
--- a/d.ts/index.d.ts
+++ b/d.ts/index.d.ts
@@ -151,6 +151,7 @@ interface CommandOptions {
 
 interface ParserOptions {
   sender: UserStateTags;
+  parameters: string;
   message: string;
   skip: boolean;
 }

--- a/locales/cs.json
+++ b/locales/cs.json
@@ -395,6 +395,7 @@
         "latestCheerMessage": "Poslední Cheer (zpráva)",
         "latestCheer": "Poslední Cheer (uživatel)",
         "version": "Bot version",
+        "haveParam": "Příkaz má parametr? (bool)",
         "is": {
           "moderator": "Je uživatel mod? (bool)",
           "subscriber": "Je uživatel sub? (bool)",

--- a/locales/en.json
+++ b/locales/en.json
@@ -390,6 +390,7 @@
         "latestCheerMessage": "Latest Cheer (message)",
         "latestCheer": "Latest Cheer (username)",
         "version": "Bot version",
+        "haveParam": "Have command parameter? (bool)",
         "is": {
           "moderator": "Is user mod? (bool)",
           "subscriber": "Is user sub? (bool)",

--- a/src/bot/parser.ts
+++ b/src/bot/parser.ts
@@ -52,9 +52,12 @@ class Parser {
       if (parser.priority !== constants.MODERATION) {
         continue;
       }; // skip non-moderation parsers
+
+      const text = this.message.trim().replace(/^(!\w+)/i, '');
       const opts = {
         sender: this.sender,
         message: this.message.trim(),
+        parameters: text.trim(),
         skip: this.skip,
       };
       const isOk = await parser.fnc.apply(parser.this, [opts]);
@@ -86,9 +89,11 @@ class Parser {
         || getFromViewersCache(this.sender.userId, parser.permission)
       ) {
         debug('parser.process', 'Processing ' + parser.name + ' (fireAndForget: ' + parser.fireAndForget + ')');
+        const text = this.message.trim().replace(/^(!\w+)/i, '');
         const opts = {
           sender: this.sender,
           message: this.message.trim(),
+          parameters: text.trim(),
           skip: this.skip,
         };
 

--- a/src/bot/systems/customcommands.ts
+++ b/src/bot/systems/customcommands.ts
@@ -240,12 +240,6 @@ class CustomCommands extends System {
 
         if (getFromViewersCache(opts.sender.userId, r.permission)
             && await this.checkFilter(opts, r.filter)) {
-          if (param.length > 0
-            && !(r.response.includes('$param')
-              || r.response.includes('$touser')
-              || r.response.search(/\$_[a-zA-Z_]*/g) >= 0)) {
-            continue;
-          }
           _responses.push(r);
           atLeastOnePermissionOk = true;
           if (r.stopIfExecuted) {
@@ -412,6 +406,7 @@ class CustomCommands extends System {
       $sender: opts.sender.username,
       $is,
       $rank,
+      $haveParam: opts.parameters.length > 0,
       // add global variables
       $game: api.stats.currentGame || 'n/a',
       $title: api.stats.currentTitle || 'n/a',

--- a/src/panel/views/managers/commands/commands-edit.vue
+++ b/src/panel/views/managers/commands/commands-edit.vue
@@ -60,7 +60,7 @@
             :value.sync="response.filter"
             v-bind:placeholder="translate('systems.customcommands.filter.placeholder')"
             v-on:update="response.filter = $event"
-            v-bind:filters="['sender', 'is.moderator', 'is.subscriber', 'is.vip', 'is.follower', 'is.broadcaster', 'is.bot', 'is.owner', 'rank', 'game', 'title', 'views', 'followers', 'hosts', 'subscribers']"></textarea-with-tags>
+            v-bind:filters="['sender', 'haveParam', 'is.moderator', 'is.subscriber', 'is.vip', 'is.follower', 'is.broadcaster', 'is.bot', 'is.owner', 'rank', 'game', 'title', 'views', 'followers', 'hosts', 'subscribers']"></textarea-with-tags>
           <div class="h-auto w-auto" style="flex-shrink: 0;">
             <b-dropdown variant="outline-dark" toggle-class="border-0 h-auto w-auto" class="h-100">
               <template v-slot:button-content>

--- a/test/tests/commands/run.js
+++ b/test/tests/commands/run.js
@@ -47,7 +47,7 @@ describe('Custom Commands - run()', () => {
     it('create \'!test\' command without $param', async () => {
       await getRepository(Commands).save({
         id: uuid(), command: '!test', enabled: true, visible: true, responses: [{
-          filter: '', response: 'This should not be triggered', permission: permission.VIEWERS, stopIfExecuted: false, order: 0,
+          filter: '!$haveParam', response: 'This should not be triggered', permission: permission.VIEWERS, stopIfExecuted: false, order: 0,
         }]
       })
     });
@@ -67,7 +67,7 @@ describe('Custom Commands - run()', () => {
     });
 
     it('run command by owner', async () => {
-      await customcommands.run({ sender: owner, message: '!test qwerty' });
+      await customcommands.run({ sender: owner, message: '!test qwerty', parameters: 'qwerty' });
       await message.isSentRaw('qwerty by !test command with param', owner);
       await message.isSentRaw('@soge__, $_variable was set to qwerty.', owner);
       await message.isSentRaw('This should be triggered', owner);
@@ -76,7 +76,7 @@ describe('Custom Commands - run()', () => {
     });
 
     it('run command by viewer', async () => {
-      await customcommands.run({ sender: user1, message: '!test qwerty' });
+      await customcommands.run({ sender: user1, message: '!test qwerty', parameters: 'qwerty' });
       await message.isSentRaw('This should be triggered', user1);
       await message.isSentRaw('This should be triggered as well', user1);
       await message.isSentRaw('qwerty by !test command with param', user1);
@@ -98,12 +98,12 @@ describe('Custom Commands - run()', () => {
     });
 
     it('run command as user not defined in filter', async () => {
-      customcommands.run({ sender: owner, message: '!cmd' });
+      customcommands.run({ sender: owner, message: '!cmd', parameters: '' });
       await message.isNotSentRaw('Lorem Ipsum', owner);
     });
 
     it('run command as user defined in filter', async () => {
-      customcommands.run({ sender: user1, message: '!cmd' });
+      customcommands.run({ sender: user1, message: '!cmd', parameters: '' });
       await message.isSentRaw('Lorem Ipsum', user1);
     });
   });
@@ -112,7 +112,7 @@ describe('Custom Commands - run()', () => {
     customcommands.add({ sender: owner, parameters: '-c !a -r Lorem Ipsum' });
     await message.isSent('customcmds.command-was-added', owner, { command: '!a', response: 'Lorem Ipsum', sender: owner.username });
 
-    customcommands.run({ sender: owner, message: '!a' });
+    customcommands.run({ sender: owner, message: '!a', parameters: '' });
     await message.isSentRaw('Lorem Ipsum', owner);
 
     customcommands.remove({ sender: owner, parameters: '!a' });
@@ -123,7 +123,7 @@ describe('Custom Commands - run()', () => {
     customcommands.add({ sender: owner, parameters: '-c !한글 -r Lorem Ipsum' });
     await message.isSent('customcmds.command-was-added', owner, { command: '!한글', response: 'Lorem Ipsum', sender: owner.username });
 
-    customcommands.run({ sender: owner, message: '!한글' });
+    customcommands.run({ sender: owner, message: '!한글', parameters: '' });
     await message.isSentRaw('Lorem Ipsum', owner);
 
     customcommands.remove({ sender: owner, parameters: '!한글' });
@@ -134,7 +134,7 @@ describe('Custom Commands - run()', () => {
     customcommands.add({ sender: owner, parameters: '-c !русский -r Lorem Ipsum' });
     await message.isSent('customcmds.command-was-added', owner, { command: '!русский', response: 'Lorem Ipsum', sender: owner.username });
 
-    customcommands.run({ sender: owner, message: '!русский' });
+    customcommands.run({ sender: owner, message: '!русский', parameters: '' });
     await message.isSentRaw('Lorem Ipsum', owner);
 
     customcommands.remove({ sender: owner, parameters: '!русский' });


### PR DESCRIPTION
This commit changes current behavior, where responses without $param are
ignored if command is sent with param.
Now user need to add filter if he want to block responses without param

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
