### PR TITLE
feat(userinfo): add !stats command

### DIFF
--- a/docs/_master/commands/miscellaneous.md
+++ b/docs/_master/commands/miscellaneous.md
@@ -17,4 +17,6 @@
 
 `!me` - shows points, rank, watched time of user and message count
 
+`!stats <optional-username>` - shows points, rank, watched time of user and message count with optional username
+
 `!top <time|points|messages>` - shows top 10 users ordered by [time|points|messages]


### PR DESCRIPTION
This command behavior is same as !me except it can have param to check
other users as well by theirs username
By default it is disabled

Fixes https://ideas.sogebot.xyz/posts/120/similar-command-as-me-for-check-other-user

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
