### PR TITLE
fix(commons): replace /me if bot is in color-mode

### DIFF
--- a/src/bot/commons.ts
+++ b/src/bot/commons.ts
@@ -123,6 +123,11 @@ export async function sendMessage(messageToSend: string | Promise<string>, sende
   attr = attr || {};
   sender = sender || null;
 
+  if (tmi.sendWithMe) {
+    // replace /me in message if we are already sending with /me
+    messageToSend = messageToSend.replace(/^(\/me)/gi, '').trim();
+  }
+
   debug('commons.sendMessage', JSON.stringify({messageToSend, sender, attr}));
 
   if (sender) {

--- a/test/tests/commons/sendMessage.js
+++ b/test/tests/commons/sendMessage.js
@@ -10,7 +10,7 @@ const assert = require('chai').assert;
 
 const { sendMessage, getOwnerAsSender } = require('../../../dest/commons');
 
-describe.only('lib/commons - sendMessage()', () => {
+describe('lib/commons - sendMessage()', () => {
   describe('remove /me when in color mode', () => {
     before(async () => {
       await db.cleanup();

--- a/test/tests/commons/sendMessage.js
+++ b/test/tests/commons/sendMessage.js
@@ -1,0 +1,52 @@
+/* global describe it before */
+
+require('../../general.js');
+
+const db = require('../../general.js').db;
+const message = require('../../general.js').message;
+
+const tmi = (require('../../../dest/tmi')).default;
+const assert = require('chai').assert;
+
+const { sendMessage, getOwnerAsSender } = require('../../../dest/commons');
+
+describe.only('lib/commons - sendMessage()', () => {
+  describe('remove /me when in color mode', () => {
+    before(async () => {
+      await db.cleanup();
+      await message.prepare();
+    });
+
+    it('enable color-mode', () => {
+      tmi.sendWithMe = true;
+    });
+
+    it('send message containing /me', () => {
+      sendMessage('/me lorem ipsum', getOwnerAsSender());
+    });
+
+    it('message is sent without /me', async () => {
+      await message.isSentRaw('lorem ipsum', getOwnerAsSender());
+    });
+  });
+
+  describe('keep /me when in normal mode', () => {
+    before(async () => {
+      await db.cleanup();
+      await message.prepare();
+    });
+
+    it('enable normal-mode', () => {
+      tmi.sendWithMe = false;
+    });
+
+    it('send message containing /me', () => {
+      sendMessage('/me lorem ipsum', getOwnerAsSender());
+    });
+
+    it('message is sent with /me', async () => {
+      await message.isSentRaw('/me lorem ipsum', getOwnerAsSender());
+    });
+  });
+
+});


### PR DESCRIPTION
Fixes https://community.sogebot.xyz/t/replace-me-when-bot-already-in-color-mode/54/7

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
