### PR TITLE
refactor(migration): update ranks migration to include viewer default

### DIFF
--- a/src/bot/database/migration/mysql/1582546819777-RanksTypes.ts
+++ b/src/bot/database/migration/mysql/1582546819777-RanksTypes.ts
@@ -6,7 +6,8 @@ export class RanksTypes1582546819777 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query('DROP INDEX `IDX_93c78c94804a13befdace81904` ON `rank`', undefined);
     await queryRunner.query('ALTER TABLE `rank` CHANGE `hours` `value` int NOT NULL', undefined);
-    await queryRunner.query('ALTER TABLE `rank` ADD `type` varchar(255) NOT NULL', undefined);
+    await queryRunner.query('ALTER TABLE `rank` ADD `type` varchar(255) NOT NULL DEFAULT "viewer"', undefined);
+    await queryRunner.query('ALTER TABLE `rank` ALTER COLUMN `type` drop default', undefined);
     await queryRunner.query('CREATE UNIQUE INDEX `IDX_93c78c94804a13befdace81904` ON `rank` (`type`, `value`)', undefined);
   }
 

--- a/src/bot/database/migration/postgres/1582546688571-RanksTypes.ts
+++ b/src/bot/database/migration/postgres/1582546688571-RanksTypes.ts
@@ -6,7 +6,8 @@ export class RanksTypes1582546688571 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
     await queryRunner.query(`DROP INDEX "IDX_93c78c94804a13befdace81904"`, undefined);
     await queryRunner.query(`ALTER TABLE "rank" RENAME COLUMN "hours" TO "value"`, undefined);
-    await queryRunner.query(`ALTER TABLE "rank" ADD "type" character varying NOT NULL`, undefined);
+    await queryRunner.query(`ALTER TABLE "rank" ADD "type" character varying NOT NULL DEFAULT 'viewer'`, undefined);
+    await queryRunner.query(`ALTER TABLE "rank" ALTER COLUMN "type" drop default`, undefined);
     await queryRunner.query(`CREATE UNIQUE INDEX "IDX_93c78c94804a13befdace81904" ON "rank" ("type", "value") `, undefined);
   }
 


### PR DESCRIPTION
Fixes #3291

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
