### PR TITLE
chore: run migration before bot start

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ytsr": "0.1.11"
   },
   "scripts": {
+    "prestart": "echo '.. Migration in progress, please wait...' && typeorm migration:run >logs/migration.log 2>&1",
     "watch": "cross-env NODE_ENV=development npx webpack --watch --progress",
     "build": "cross-env ENV=development make bot",
     "test": "node tools/runTests.js",


### PR DESCRIPTION
We will have proper logs in logs/migration.log
and bot will start when migration is done

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
