### PR TITLE
fix(api): add clientId to all Bearer requests

### DIFF
--- a/src/bot/api.ts
+++ b/src/bot/api.ts
@@ -379,6 +379,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -431,6 +432,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -520,6 +522,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -607,6 +610,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -813,6 +817,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
       });
       ioServer?.emit('api.stats', { data: request.data, timestamp: Date.now(), call: 'updateChannelViewsAndBroadcasterType', api: 'helix', endpoint: url, code: request.status, remaining: this.calls.bot.remaining });
@@ -855,6 +860,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -917,6 +923,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -991,6 +998,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1045,6 +1053,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1095,6 +1104,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1330,6 +1340,7 @@ class API extends Core {
         headers: {
           'Authorization': 'Bearer ' + token,
           'Content-Type': 'application/json',
+          'Client-ID': oauth.botClientId,
         },
       });
       await getRepository(TwitchTag).update({ is_auto: false }, { is_current: false });
@@ -1505,6 +1516,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1576,6 +1588,7 @@ class API extends Core {
         url,
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
       });
 
@@ -1671,6 +1684,7 @@ class API extends Core {
       request = await axios.get(url, {
         headers: {
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1762,6 +1776,7 @@ class API extends Core {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         data: {
           user_id: String(cid),
@@ -1798,6 +1813,7 @@ class API extends Core {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });
@@ -1845,6 +1861,7 @@ class API extends Core {
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
         timeout: 20000,
       });

--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -661,6 +661,7 @@ class Message {
           request = await axios.get(`https://api.twitch.tv/helix/streams?user_id=${channelId}`, {
             headers: {
               'Authorization': 'Bearer ' + token,
+              'Client-ID': oauth.botClientId,
             },
           });
           return api.getGameFromId(request.data.data[0].game_id);
@@ -688,6 +689,7 @@ class Message {
           request = await axios.get(`https://api.twitch.tv/helix/streams?user_id=${channelId}`, {
             headers: {
               'Authorization': 'Bearer ' + token,
+              'Client-ID': oauth.botClientId,
             },
           });
           // save remaining api calls
@@ -717,6 +719,7 @@ class Message {
           request = await axios.get(`https://api.twitch.tv/helix/streams?user_id=${channelId}`, {
             headers: {
               'Authorization': 'Bearer ' + token,
+              'Client-ID': oauth.botClientId,
             },
           });
           // save remaining api calls

--- a/src/bot/microservices/getUserFromTwitch.ts
+++ b/src/bot/microservices/getUserFromTwitch.ts
@@ -28,6 +28,13 @@ export const getUserFromTwitch = async (username)  => {
     },
   });
 
+  const clientId = await getRepository(Settings).findOne({
+    where: {
+      name: 'botClientId',
+      namespace: '/core/oauth',
+    },
+  });
+
   if (!token) {
     throw Error('Missing oauth token');
   }
@@ -35,6 +42,7 @@ export const getUserFromTwitch = async (username)  => {
   const request = await axios.get(url, {
     headers: {
       'Authorization': 'Bearer ' + JSON.parse(token.value),
+      'Client-ID': clientId,
     },
   });
 

--- a/src/bot/oauth.ts
+++ b/src/bot/oauth.ts
@@ -27,13 +27,15 @@ class OAuth extends Core {
   @shared()
   public bot = '';
   @shared()
-  public clientId = '';
-  @shared()
   public channelId = '';
   @shared()
   public botId = '';
+  @shared(true)
+  public botClientId = '';
   @shared()
   public broadcasterId = '';
+  @shared(true)
+  public broadcasterClientId = '';
 
   @settings('general')
   public generalChannel = '';
@@ -227,11 +229,12 @@ class OAuth extends Core {
         throw new Error(`Error on validate ${type} OAuth token, error: ${errorMessage}`);
       }
 
-      this.clientId = request.data.client_id;
 
       if (type === 'bot') {
+        this.botClientId = request.data.client_id;
         this.botId = request.data.user_id;
       } else {
+        this.broadcasterClientId = request.data.client_id;
         this.broadcasterId = request.data.user_id;
       }
 

--- a/src/bot/systems/highlights.ts
+++ b/src/bot/systems/highlights.ts
@@ -97,6 +97,7 @@ class Highlights extends System {
       const request = await axios.get(url, {
         headers: {
           Authorization: 'Bearer ' + token,
+          'Client-ID': oauth.botClientId,
         },
       });
       // save remaining api calls

--- a/src/bot/users.ts
+++ b/src/bot/users.ts
@@ -310,6 +310,7 @@ class Users extends Core {
           headers: {
             'Accept': 'application/vnd.twitchtv.v5+json',
             'Authorization': 'Bearer ' + token,
+            'Client-ID': oauth.botClientId,
           },
         });
         if (request.data.total === 0) {

--- a/src/bot/webhooks.ts
+++ b/src/bot/webhooks.ts
@@ -52,7 +52,7 @@ class Webhooks {
     clearTimeout(this.timeouts[`unsubscribe-${type}`]);
 
     const cid = oauth.channelId;
-    const clientId = await oauth.clientId;
+    const clientId = await oauth.botClientId;
     if (cid === '' || clientId === '') {
       this.timeouts[`unsubscribe-${type}`] = setTimeout(() => this.subscribe(type), 1000);
       return;
@@ -104,7 +104,7 @@ class Webhooks {
     clearTimeout(this.timeouts[`subscribe-${type}`]);
 
     const cid = oauth.channelId;
-    const clientId = await oauth.clientId;
+    const clientId = await oauth.botClientId;
     if (cid === '' || clientId === '') {
       this.timeouts[`subscribe-${type}`] = setTimeout(() => this.subscribe(type), 1000);
       return;

--- a/src/panel/helpers/isUserLoggedIn.ts
+++ b/src/panel/helpers/isUserLoggedIn.ts
@@ -21,9 +21,23 @@ export const isUserLoggedIn = async function (mustBeLogged = true, mustBeAdmin =
     }
   } else {
     try {
+      let clientId = localStorage.getItem('clientId') || '';
+      if (clientId.length === 0) {
+        // we need first get useless clientId
+        const dumbClientIdData = await axios.get(`https://id.twitch.tv/oauth2/validate`, {
+          headers: {
+            'Authorization': 'OAuth ' + code,
+          },
+        });
+        clientId = dumbClientIdData.data.client_id;
+        console.log(clientId);
+        localStorage.setItem('clientId', clientId);
+      }
+
       const axiosData = await axios.get(`https://api.twitch.tv/helix/users`, {
         headers: {
           'Authorization': 'Bearer ' + code,
+          'Client-Id': clientId,
         },
       });
       const data = get(axiosData, 'data.data[0]', null);


### PR DESCRIPTION
per https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916
we need to append clientId just because.

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
