### PR TITLE
feat(alias): add alias grouping

### DIFF
--- a/docs/_master/filters/all.md
+++ b/docs/_master/filters/all.md
@@ -234,7 +234,15 @@ e.g. `(api|https://httpbin.org/get?test=a\\nb) Lorem (api.args.test)`
 ## List filters
 `(list.alias)` - will return list of your visible aliases
 
+`(list.alias|<group>)` - will return list of your visible aliases for group
+
+`(list.alias|)` - will return list of your visible aliases without any group
+
 `(list.!alias)` - will return list of your visible !aliases
+
+`(list.!alias|<group>)` - will return list of your visible !aliases for group
+
+`(list.!alias|<group>)` - will return list of your visible !aliases without any group
 
 `(list.price)` - will return list of your set prices
 

--- a/docs/_master/systems/alias.md
+++ b/docs/_master/systems/alias.md
@@ -132,6 +132,71 @@
   <strong>bot:</strong> @testuser, alias !uec was exposed
 </blockquote>
 
+## Set an alias to group
+
+`!alias group -set <group> -a <!alias>`
+
+!> Default permission is **OWNER**
+
+### Parameters
+
+- `<group>` - group to be set
+- `<!alias>` - alias to be set into group
+
+### Examples
+
+<blockquote>
+  <strong>testuser:</strong>!alias group -set voice -a !yes <br>
+  <strong>bot:</strong> @testuser, alias !yes was set to group voice
+</blockquote>
+
+## Unset an alias group
+
+`!alias group -unset <!alias>`
+
+!> Default permission is **OWNER**
+
+### Parameters
+
+- `<!alias>` - alias to be unset from group
+
+### Examples
+
+<blockquote>
+  <strong>testuser:</strong>!alias group -unset !yes <br>
+  <strong>bot:</strong> @testuser, alias !yes group was unset
+</blockquote>
+
+## List all alias groups
+
+`!alias group -list`
+
+!> Default permission is **OWNER**
+
+### Examples
+
+<blockquote>
+  <strong>testuser:</strong>!alias group -list <br>
+  <strong>bot:</strong> @testuser, list of aliases groups: voice
+</blockquote>
+
+## List all aliases in group
+
+`!alias group -list <group>`
+
+!> Default permission is **OWNER**
+
+### Parameters
+
+- `<group>` - group to list aliases
+
+### Examples
+
+<blockquote>
+  <strong>testuser:</strong>!alias group -list voice <br>
+  <strong>bot:</strong> @testuser, list of aliases in voice: !yes
+</blockquote>
+
 ## Other settings
 
 ### Enable or disable alias system

--- a/locales/en.json
+++ b/locales/en.json
@@ -840,7 +840,12 @@
     "alias-was-disabled": "$sender, alias $alias was disabled",
     "alias-was-concealed": "$sender, alias $alias was concealed",
     "alias-was-exposed": "$sender, alias $alias was exposed",
-    "alias-was-removed": "$sender, alias $alias was removed"
+    "alias-was-removed": "$sender, alias $alias was removed",
+    "alias-group-set": "$sender, alias $alias was set to group $group",
+    "alias-group-unset": "$sender, alias $alias group was unset",
+    "alias-group-list": "$sender, list of aliases groups: $list",
+    "alias-group-list-aliases": "$sender, list of aliases in $group: $list"
+
   },
   "customcmds": {
     "commands-parse-failed": "{core.command-parse} !commands",

--- a/src/bot/database/entity/alias.ts
+++ b/src/bot/database/entity/alias.ts
@@ -7,6 +7,7 @@ export interface AliasInterface {
   enabled: boolean;
   visible: boolean;
   permission: string;
+  group: string | null;
 }
 
 export const Alias = new EntitySchema<Readonly<Required<AliasInterface>>>({
@@ -18,6 +19,7 @@ export const Alias = new EntitySchema<Readonly<Required<AliasInterface>>>({
     enabled: { type: Boolean },
     visible: { type: Boolean },
     permission: { type: String },
+    group: { type: String, nullable: true },
   },
   indices: [
     { name: 'IDX_6a8a594f0a5546f8082b0c405c', columns: ['alias'] },

--- a/src/bot/database/migration/mysql/1589290695701-aliasGroup.ts
+++ b/src/bot/database/migration/mysql/1589290695701-aliasGroup.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from 'typeorm';
+
+export class aliasGroup1589290695701 implements MigrationInterface {
+  name = 'aliasGroup1589290695701';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `alias` ADD `group` varchar(255) NULL', undefined);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE `alias` DROP COLUMN `group`', undefined);
+  }
+
+}

--- a/src/bot/database/migration/postgres/1589290567071-aliasGroup.ts
+++ b/src/bot/database/migration/postgres/1589290567071-aliasGroup.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from 'typeorm';
+
+export class aliasGroup1589290567071 implements MigrationInterface {
+  name = 'aliasGroup1589290567071';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alias" ADD "group" character varying`, undefined);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "alias" DROP COLUMN "group"`, undefined);
+  }
+
+}

--- a/src/bot/database/migration/sqlite/1589283262462-aliasGroup.ts
+++ b/src/bot/database/migration/sqlite/1589283262462-aliasGroup.ts
@@ -1,0 +1,24 @@
+import {MigrationInterface, QueryRunner} from 'typeorm';
+
+export class aliasGroup1589283262462 implements MigrationInterface {
+  name = 'aliasGroup1589283262462';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_6a8a594f0a5546f8082b0c405c"`, undefined);
+    await queryRunner.query(`CREATE TABLE "temporary_alias" ("id" varchar PRIMARY KEY NOT NULL, "alias" varchar NOT NULL, "command" text NOT NULL, "enabled" boolean NOT NULL, "visible" boolean NOT NULL, "permission" varchar NOT NULL, "group" varchar)`, undefined);
+    await queryRunner.query(`INSERT INTO "temporary_alias"("id", "alias", "command", "enabled", "visible", "permission") SELECT "id", "alias", "command", "enabled", "visible", "permission" FROM "alias"`, undefined);
+    await queryRunner.query(`DROP TABLE "alias"`, undefined);
+    await queryRunner.query(`ALTER TABLE "temporary_alias" RENAME TO "alias"`, undefined);
+    await queryRunner.query(`CREATE INDEX "IDX_6a8a594f0a5546f8082b0c405c" ON "alias" ("alias") `, undefined);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_6a8a594f0a5546f8082b0c405c"`, undefined);
+    await queryRunner.query(`ALTER TABLE "alias" RENAME TO "temporary_alias"`, undefined);
+    await queryRunner.query(`CREATE TABLE "alias" ("id" varchar PRIMARY KEY NOT NULL, "alias" varchar NOT NULL, "command" text NOT NULL, "enabled" boolean NOT NULL, "visible" boolean NOT NULL, "permission" varchar NOT NULL)`, undefined);
+    await queryRunner.query(`INSERT INTO "alias"("id", "alias", "command", "enabled", "visible", "permission") SELECT "id", "alias", "command", "enabled", "visible", "permission" FROM "temporary_alias"`, undefined);
+    await queryRunner.query(`DROP TABLE "temporary_alias"`, undefined);
+    await queryRunner.query(`CREATE INDEX "IDX_6a8a594f0a5546f8082b0c405c" ON "alias" ("alias") `, undefined);
+  }
+
+}

--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -439,9 +439,18 @@ class Message {
     };
     const list = {
       '(list.#)': async function (filter: string) {
-        const [system, permission] = filter.replace('(list.', '').replace(')', '').split('.');
+        const [main, permission] = filter.replace('(list.', '').replace(')', '').split('.');
+        let system = main;
+        let group: null | string | undefined = undefined;
+        if (main.includes('|')) {
+          [system, group] = main.split('|');
+          if (group.trim().length === 0) {
+            group = null;
+          }
+        }
+        console.log({system, group});
         let [alias, commands, cooldowns, ranks, prices] = await Promise.all([
-          getRepository(Alias).find({ where: { visible: true, enabled: true } }),
+          getRepository(Alias).find({ where: typeof group !== 'undefined' ? { visible: true, enabled: true, group } : { visible: true, enabled: true } }),
           getRepository(Commands).find({ relations: ['responses'], where: { visible: true, enabled: true } }),
           getRepository(Cooldown).find({ where: { enabled: true } }),
           getRepository(Rank).find(),

--- a/src/bot/systems/keywords.ts
+++ b/src/bot/systems/keywords.ts
@@ -71,9 +71,9 @@ class Keywords extends System {
   @command('!keyword')
   @default_permission(permission.CASTERS)
   public main(opts: CommandOptions): CommandResponse[] {
-    let url = 'http://sogehige.github.io/sogeBot/#/commands/keywords';
+    let url = 'http://sogehige.github.io/sogeBot/#/systems/keywords';
     if ((process.env?.npm_package_version ?? 'x.y.z-SNAPSHOT').includes('SNAPSHOT')) {
-      url = 'http://sogehige.github.io/sogeBot/#/_master/commands/keywords';
+      url = 'http://sogehige.github.io/sogeBot/#/_master/systems/keywords';
     }
     return [{ response: translate('core.usage') + ' => ' + url, ...opts }];
   }

--- a/src/bot/systems/ranks.ts
+++ b/src/bot/systems/ranks.ts
@@ -190,9 +190,9 @@ class Ranks extends System {
   @command('!rank help')
   @default_permission(permission.CASTERS)
   help (opts): CommandResponse[] {
-    let url = 'http://sogehige.github.io/sogeBot/#/commands/ranks';
+    let url = 'http://sogehige.github.io/sogeBot/#/systems/ranks';
     if ((process.env?.npm_package_version ?? 'x.y.z-SNAPSHOT').includes('SNAPSHOT')) {
-      url = 'http://sogehige.github.io/sogeBot/#/_master/commands/ranks';
+      url = 'http://sogehige.github.io/sogeBot/#/_master/systems/ranks';
     }
     return [{ response: translate('core.usage') + ' => ' + url, ...opts }];
   }

--- a/src/bot/systems/timers.ts
+++ b/src/bot/systems/timers.ts
@@ -94,9 +94,9 @@ class Timers extends System {
   @command('!timers')
   @default_permission(permission.CASTERS)
   main (opts): CommandResponse[] {
-    let url = 'http://sogehige.github.io/sogeBot/#/commands/timers';
+    let url = 'http://sogehige.github.io/sogeBot/#/systems/timers';
     if ((process.env?.npm_package_version ?? 'x.y.z-SNAPSHOT').includes('SNAPSHOT')) {
-      url = 'http://sogehige.github.io/sogeBot/#/_master/commands/timers';
+      url = 'http://sogehige.github.io/sogeBot/#/_master/systems/timers';
     }
     return [{ response: translate('core.usage') + ' => ' + url, ...opts }];
   }

--- a/src/panel/views/managers/alias/alias-edit.vue
+++ b/src/panel/views/managers/alias/alias-edit.vue
@@ -138,6 +138,7 @@ export default class aliasEdit extends Vue {
     enabled: true,
     visible: true,
     permission: permission.VIEWERS,
+    group: null,
   }
 
 

--- a/src/panel/views/managers/alias/alias-list.vue
+++ b/src/panel/views/managers/alias/alias-list.vue
@@ -28,34 +28,83 @@
     <b-alert show v-else-if="state.loadingAls === $state.success && state.loadingPrm === $state.success && items.length === 0">
       {{translate('systems.alias.empty')}}
     </b-alert>
-    <b-table v-else striped small hover :items="fItems" :fields="fields" @row-clicked="linkTo($event)" >
-      <template v-slot:cell(buttons)="data">
-        <div class="float-right" style="width: max-content !important;">
-          <button-with-icon :class="[ data.item.enabled ? 'btn-success' : 'btn-danger' ]" class="btn-only-icon btn-reverse" icon="power-off" @click="data.item.enabled = !data.item.enabled; update(data.item)">
-            {{ translate('dialog.buttons.' + (data.item.enabled? 'enabled' : 'disabled')) }}
-          </button-with-icon>
-          <button-with-icon class="btn-only-icon btn-primary btn-reverse" icon="edit" v-bind:href="'#/manage/alias/edit/' + data.item.id">
-            {{ translate('dialog.buttons.edit') }}
-          </button-with-icon>
-          <b-dropdown no-caret class="alias-table-btn">
-            <template v-slot:button-content><fa icon="key" fixed-width/></template>
-            <b-dropdown-item
-              v-for="permission of permissions"
-              :key="data.item.id + permission.id"
-              @click="updatePermission(data.item.id, permission.id)">
-              {{ permission.name }}
-            </b-dropdown-item>
-          </b-dropdown>
-          <button-with-icon class="btn-only-icon btn-dark btn-reverse" :icon="['fas', data.item.visible ? 'eye' : 'eye-slash']" @click="data.item.visible = !data.item.visible; update(data.item)">
-            {{ translate('dialog.buttons.edit') }}
-          </button-with-icon>
-          <hold-button @trigger="remove(data.item.id)" icon="trash" class="btn-danger btn-reverse btn-only-icon">
-            <template slot="title">{{translate('dialog.buttons.delete')}}</template>
-            <template slot="onHoldTitle">{{translate('dialog.buttons.hold-to-delete')}}</template>
-          </hold-button>
-        </div>
-      </template>
-    </b-table>
+    <b-card v-else no-body v-for="group of groups" v-bind:key="group">
+      <b-card-header header-tag="header" class="p-1" role="tab">
+        <b-button block href="#" v-b-toggle="'alias-accordion-' + group" variant="dark" class="text-left">
+          {{group === null ? 'Unnassigned group' : group }} ({{ fItems.filter(o => o.group === group).length }})
+        </b-button>
+      </b-card-header>
+      <b-collapse :id="'alias-accordion-' + group" accordion="alias-accordion" role="tabpanel" :visible="group === null">
+        <b-card-body>
+          <b-table striped small hover :items="fItems.filter(o => o.group === group)" :fields="fields" @row-clicked="linkTo($event)" >
+            <template v-slot:cell(buttons)="data">
+              <div class="float-right" style="width: max-content !important;">
+                <button-with-icon :class="[ data.item.enabled ? 'btn-success' : 'btn-danger' ]" class="btn-only-icon btn-reverse" icon="power-off" @click="data.item.enabled = !data.item.enabled; update(data.item)">
+                  {{ translate('dialog.buttons.' + (data.item.enabled? 'enabled' : 'disabled')) }}
+                </button-with-icon>
+                <button-with-icon class="btn-only-icon btn-primary btn-reverse" icon="edit" v-bind:href="'#/manage/alias/edit/' + data.item.id">
+                  {{ translate('dialog.buttons.edit') }}
+                </button-with-icon>
+                <b-dropdown no-caret class="alias-table-btn">
+                  <template v-slot:button-content><fa icon="key" fixed-width/></template>
+                  <b-dropdown-item
+                    v-for="permission of permissions"
+                    :key="data.item.id + permission.id"
+                    @click="updatePermission(data.item.id, permission.id)">
+                    {{ permission.name }}
+                  </b-dropdown-item>
+                </b-dropdown>
+                <b-dropdown no-caret class="alias-table-btn">
+                  <template v-slot:button-content><fa icon="object-group" fixed-width/></template>
+                  <b-dropdown-item
+                    v-for="group of groups"
+                    :key="data.item.id + group"
+                    @click="updateGroup(data.item.id, group)">
+                    {{ group === null ? 'Unnassigned group' : group }}
+                  </b-dropdown-item>
+                  <b-dropdown-divider/>
+                  <b-dropdown-item
+                    v-b-modal.create-new-group
+                    @click="newGroupForAliasId = data.item.id"
+                    :key="data.item.id + 'newgroup'">
+                    Add new group
+                  </b-dropdown-item>
+                </b-dropdown>
+                <button-with-icon class="btn-only-icon btn-dark btn-reverse" :icon="['fas', data.item.visible ? 'eye' : 'eye-slash']" @click="data.item.visible = !data.item.visible; update(data.item)">
+                  {{ translate('dialog.buttons.edit') }}
+                </button-with-icon>
+                <hold-button @trigger="remove(data.item.id)" icon="trash" class="btn-danger btn-reverse btn-only-icon">
+                  <template slot="title">{{translate('dialog.buttons.delete')}}</template>
+                  <template slot="onHoldTitle">{{translate('dialog.buttons.hold-to-delete')}}</template>
+                </hold-button>
+              </div>
+            </template>
+          </b-table>
+        </b-card-body>
+      </b-collapse>
+    </b-card>
+
+    <b-modal id="create-new-group" title="New group name" centered
+      @show="resetModal"
+      @hidden="resetModal"
+      @ok="handleOk">
+      <form ref="form" @submit.stop.prevent="handleSubmit">
+        <b-form-group
+          :state="newGroupNameValidity"
+          label="Name"
+          label-for="name-input"
+          invalid-feedback="Name is required"
+        >
+          <b-form-input
+            id="name-input"
+            v-model="newGroupName"
+            :state="newGroupNameValidity"
+            @keydown="newGroupNameUpdated = true"
+            required
+          ></b-form-input>
+        </b-form-group>
+      </form>
+    </b-modal>
   </b-container>
 </template>
 
@@ -70,8 +119,8 @@ import { orderBy, isNil } from 'lodash-es';
 import { escape } from 'xregexp';
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faKey } from '@fortawesome/free-solid-svg-icons';
-library.add(faKey);
+import { faKey, faObjectGroup } from '@fortawesome/free-solid-svg-icons';
+library.add(faKey, faObjectGroup);
 
 @Component({
   components: {
@@ -85,6 +134,11 @@ export default class aliasList extends Vue {
 
   items: AliasInterface[] = [];
   permissions: PermissionsInterface[] = [];
+
+  newGroupForAliasId = '';
+  newGroupName = '';
+  newGroupNameUpdated = false;
+
   search: string = '';
   state: {
     loadingAls: number;
@@ -106,6 +160,42 @@ export default class aliasList extends Vue {
       sortByFormatted: true, },
     { key: 'buttons', label: '' },
   ];
+
+  resetModal() {
+    this.newGroupName = '';
+    this.newGroupNameUpdated = false;
+  }
+
+  handleOk(bvModalEvt) {
+    // Prevent modal from closing
+    bvModalEvt.preventDefault()
+    // Trigger submit handler
+    this.handleSubmit()
+  }
+
+  handleSubmit() {
+    if (!this.newGroupNameValidity) {
+      return;
+    }
+
+    this.updateGroup(this.newGroupForAliasId, this.newGroupName);
+    // Hide the modal manually
+    this.$nextTick(() => {
+      this.$bvModal.hide('create-new-group')
+    })
+  }
+
+  get newGroupNameValidity() {
+    if (this.newGroupNameUpdated) {
+      return this.newGroupName.length > 0;
+    } else {
+      return null;
+    }
+  }
+
+  get groups() {
+    return [null, ...new Set(this.items.filter(o => o.group !== null).map(o => o.group).sort())];
+  }
 
   get fItems() {
     if (this.search.length === 0) return this.items
@@ -143,6 +233,13 @@ export default class aliasList extends Vue {
     } else {
       return null
     }
+  }
+
+  updateGroup (id, group) {
+    let item = this.items.filter((o) => o.id === id)[0]
+    item.group = group
+    this.socket.emit('setById', item.id, item, () => {})
+    this.$forceUpdate();
   }
 
   updatePermission (id, permission) {


### PR DESCRIPTION
Alias grouping is done through `!alias group` command

e.g.
!alias group -set group -a !test
!alias group -unset !test
!alias group -list
!alias group -list group

also added message filter to filter aliases with groups
(list.alias|group)
(list.!alias|group)

Fixes #3721

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
