### PR TITLE
perf(parser): getCommandsList use cached permission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sogebot",
-  "version": "11.2.0-SNAPSHOT",
+  "version": "11.3.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/bot/_interface.ts
+++ b/src/bot/_interface.ts
@@ -18,7 +18,7 @@ import { isDbConnected } from './helpers/database';
 import { register } from './helpers/register';
 import { addMenu, addMenuPublic, addWidget, ioServer, menuPublic } from './helpers/panel';
 import { v4 as uuid } from 'uuid';
-import { refreshCachedCommandPermissions } from './helpers/commands/pcache';
+import { refreshCachedCommandPermissions } from './helpers/commands/pCache';
 
 let socket: import('./socket').Socket | any = null;
 

--- a/src/bot/_interface.ts
+++ b/src/bot/_interface.ts
@@ -18,7 +18,7 @@ import { isDbConnected } from './helpers/database';
 import { register } from './helpers/register';
 import { addMenu, addMenuPublic, addWidget, ioServer, menuPublic } from './helpers/panel';
 import { v4 as uuid } from 'uuid';
-import { refreshCachedCommandPermissions } from './parser';
+import { refreshCachedCommandPermissions } from './helpers/commands/pcache';
 
 let socket: import('./socket').Socket | any = null;
 

--- a/src/bot/_interface.ts
+++ b/src/bot/_interface.ts
@@ -18,6 +18,7 @@ import { isDbConnected } from './helpers/database';
 import { register } from './helpers/register';
 import { addMenu, addMenuPublic, addWidget, ioServer, menuPublic } from './helpers/panel';
 import { v4 as uuid } from 'uuid';
+import { refreshCachedCommandPermissions } from './parser';
 
 let socket: import('./socket').Socket | any = null;
 
@@ -347,6 +348,7 @@ class Module {
                   }
                 }
               }
+              refreshCachedCommandPermissions();
             } else if (key === 'enabled') {
               this.status({ state: value });
             } else if (key === 'commands') {

--- a/src/bot/helpers/commands/pCache.ts
+++ b/src/bot/helpers/commands/pCache.ts
@@ -1,0 +1,27 @@
+import type { PermissionCommandsInterface } from '../../database/entity/permissions';
+
+import { getRepository } from 'typeorm';
+import { PermissionCommands } from '../../database/entity/permissions';
+
+import { debug } from '../log';
+import { isDbConnected } from '../database';
+
+const cachedCommandsPermissions: PermissionCommandsInterface[] = [];
+const refreshCachedCommandPermissions = () => {
+  if (!isDbConnected) {
+    setTimeout(() => refreshCachedCommandPermissions(), 1000);
+    return;
+  }
+  getRepository(PermissionCommands).find().then(values => {
+    while(cachedCommandsPermissions.length){
+      cachedCommandsPermissions.shift();
+    }
+    for (const value of values) {
+      debug('parser.command', `Command '${value.name}' permission '${value.permission}' cached.`);
+      cachedCommandsPermissions.push(value);
+    }
+  });
+};
+refreshCachedCommandPermissions();
+
+export { cachedCommandsPermissions, refreshCachedCommandPermissions };

--- a/src/bot/parser.ts
+++ b/src/bot/parser.ts
@@ -17,7 +17,7 @@ import tmi from './tmi';
 import { list } from './helpers/register';
 
 const cachedCommandsPermissions: PermissionCommandsInterface[] = [];
-export const refreshCachedCommandPermissions = () => {
+const refreshCachedCommandPermissions = () => {
   getRepository(PermissionCommands).find().then(values => {
     while(cachedCommandsPermissions.length){
       cachedCommandsPermissions.shift();
@@ -338,4 +338,4 @@ class Parser {
 }
 
 export default Parser;
-export { Parser };
+export { Parser, refreshCachedCommandPermissions };

--- a/src/bot/parser.ts
+++ b/src/bot/parser.ts
@@ -224,6 +224,9 @@ class Parser {
   }
 
   async getCommandsList () {
+    if(isDebugEnabled('parser.command')) {
+      debug('parser.command', `Call stack ${(new Error()).stack ?? ''}`); // TODO: remove after fixed loop after end of stream
+    }
     let commands: any[] = [];
     for (let i = 0, length = this.list.length; i < length; i++) {
       if (_.isFunction(this.list[i].commands)) {
@@ -232,10 +235,7 @@ class Parser {
     }
     commands = _(await Promise.all(commands)).flatMap().sortBy(o => -o.command.length).value();
     for (const command of commands) {
-      if(isDebugEnabled('parser.command')) {
-        debug('parser.command', `Checking permission for ${command.name} ${command.id}`);
-        debug('parser.command', `Call stack ${(new Error()).stack ?? ''}`); // TODO: remove after fixed loop after end of stream
-      }
+      debug('parser.command', `Checking permission for ${command.name} ${command.id}`);
       const permission = cachedCommandsPermissions.find(cachedPermission => cachedPermission.id === command.id);
       if (permission) {
         command.permission = permission.permission;

--- a/src/bot/parser.ts
+++ b/src/bot/parser.ts
@@ -13,7 +13,7 @@ import currency from './currency';
 import general from './general';
 import tmi from './tmi';
 import { list } from './helpers/register';
-import { cachedCommandsPermissions } from './helpers/commands/pcache';
+import { cachedCommandsPermissions } from './helpers/commands/pCache';
 
 class Parser {
   started_at = Date.now();

--- a/src/bot/parser.ts
+++ b/src/bot/parser.ts
@@ -3,8 +3,6 @@ import * as constants from './constants';
 import { getBotSender } from './commons';
 import { debug, error, isDebugEnabled, warning } from './helpers/log';
 import { incrementCountOfCommandUsage } from './helpers/commands/count';
-import { getRepository } from 'typeorm';
-import { PermissionCommands, PermissionCommandsInterface } from './database/entity/permissions';
 import { addToViewersCache, getFromViewersCache } from './helpers/permissions';
 import permissions from './permissions';
 import events from './events';
@@ -15,20 +13,7 @@ import currency from './currency';
 import general from './general';
 import tmi from './tmi';
 import { list } from './helpers/register';
-
-const cachedCommandsPermissions: PermissionCommandsInterface[] = [];
-const refreshCachedCommandPermissions = () => {
-  getRepository(PermissionCommands).find().then(values => {
-    while(cachedCommandsPermissions.length){
-      cachedCommandsPermissions.shift();
-    }
-    for (const value of values) {
-      cachedCommandsPermissions.push(value);
-    }
-    debug('parser.command', `Command permission cached ${cachedCommandsPermissions.length}`);
-  });
-};
-refreshCachedCommandPermissions();
+import { cachedCommandsPermissions } from './helpers/commands/pcache';
 
 class Parser {
   started_at = Date.now();
@@ -338,4 +323,4 @@ class Parser {
 }
 
 export default Parser;
-export { Parser, refreshCachedCommandPermissions };
+export { Parser };

--- a/src/bot/twitch.ts
+++ b/src/bot/twitch.ts
@@ -8,7 +8,6 @@ import { command, default_permission, settings } from './decorators';
 import { permission } from './helpers/permissions';
 import Core from './_interface';
 
-
 import { adminEndpoint } from './helpers/socket';
 
 import { getRepository } from 'typeorm';


### PR DESCRIPTION
getCommandsList should not query for each command permission. This
can lead to some performance issues during loop on end of stream.

I also added error stack to find what might be calling getCommandsList so much after stream ended and there is no traffic.

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
