### PR TITLE
fix(ui): use sockets directly and remove manager

### DIFF
--- a/src/bot/helpers/panel.ts
+++ b/src/bot/helpers/panel.ts
@@ -28,6 +28,7 @@ export const addWidget = (id, name, icon) => {
 
 export const setIOServer = (serverArg) => {
   ioServer = io(serverArg);
+  ioServer.sockets.setMaxListeners(200);
 };
 
 export const setApp = (_app) => {

--- a/src/oauth/index.html
+++ b/src/oauth/index.html
@@ -22,7 +22,8 @@
       localStorage.setItem('code', code);
 
       // set it as new authorization
-      localStorage.setItem('newAuthorization', true);
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
 
       window.location.replace(`${state.referrer || state.popoutUrl || state.url}`);
     } catch (error) {

--- a/src/panel/helpers/socket.ts
+++ b/src/panel/helpers/socket.ts
@@ -113,7 +113,6 @@ export const getTranslations = async () => {
   console.debug('Getting translations');
   return new Promise((resolve) => {
     const loop = setInterval(() => {
-      console.log(getSocket('/', true));
       getSocket('/', true).emit('translations', (translations) => {
         clearInterval(loop);
         console.debug({translations});

--- a/src/panel/helpers/socket.ts
+++ b/src/panel/helpers/socket.ts
@@ -1,12 +1,11 @@
-import { Manager } from 'socket.io-client';
+import io from 'socket.io-client';
 import { setTranslations } from './translate';
 
 import type { SocketInterface } from 'src/bot/database/entity/socket';
 
-const manager = new Manager(window.location.origin);
-manager.connect();
-
 let authorizeInProgress = false;
+
+const sockets: Map<string, SocketIOClient.Socket> = new Map();
 
 const waitForAuthorization = async () => {
   return new Promise((resolve) => {
@@ -24,7 +23,7 @@ const waitForAuthorization = async () => {
 const authorize = async(cb, namespace: string) => {
   await waitForAuthorization();
   authorizeInProgress = true;
-  const token = localStorage.getItem('accessToken') || '';
+  const token = localStorage.getItem('accessToken') || null;
   console.groupCollapsed('socket::authorize ' + namespace);
   console.debug({token, type: 'access'});
   console.groupEnd();
@@ -32,7 +31,10 @@ const authorize = async(cb, namespace: string) => {
 };
 
 const refreshToken = async(cb) => {
-  const token = localStorage.getItem('refreshToken') || '';
+  // we expected that access token is invalid
+  localStorage.removeItem('accessToken');
+
+  const token = localStorage.getItem('refreshToken') || null;
   const userId = Number(localStorage.getItem('userId') || 0);
   const type = 'refresh';
   console.groupCollapsed('socket::refreshToken');
@@ -63,12 +65,16 @@ export const redirectLogin = () => {
 
 export async function waitForAuthorizationSocket(namespace: string) {
   return new Promise((resolve: (value?: string) => void, reject) => {
-    if (!Object.keys(manager.nsps).includes(namespace)) {
-      const socket = manager.socket(namespace);
+    if (!sockets.has(namespace)) {
+      const socket = io(namespace, { forceNew: true });
+      sockets.set(namespace, socket);
       socket.on('authorize', (cb) => authorize(cb, namespace));
       socket.on('refreshToken', refreshToken);
       socket.on('authorized', (cb: Readonly<SocketInterface>) => authorized(cb, namespace, resolve));
       socket.on('unauthorized', () => {
+        // remove accessToken and refreshToken
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
         localStorage.setItem('userType', 'unauthorized');
         authorizeInProgress = false;
         resolve('unauthorized');
@@ -78,12 +84,17 @@ export async function waitForAuthorizationSocket(namespace: string) {
 };
 
 export function getSocket(namespace: string, continueOnUnauthorized = false) {
-  if (!Object.keys(manager.nsps).includes(namespace)) {
-    const socket = manager.socket(namespace);
+  if (!sockets.has(namespace)) {
+    const socket = io(namespace, { forceNew: true });
+    sockets.set(namespace, socket);
     socket.on('authorize', (cb) => authorize(cb, namespace));
     socket.on('refreshToken', refreshToken);
     socket.on('authorized', (cb: Readonly<SocketInterface>) => authorized(cb, namespace));
     socket.on('unauthorized', (cb) => {
+      // remove accessToken and refreshToken
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+
       localStorage.setItem('userType', 'unauthorized');
       if (!continueOnUnauthorized) {
         console.debug(window.location.href);
@@ -95,17 +106,21 @@ export function getSocket(namespace: string, continueOnUnauthorized = false) {
       authorizeInProgress = false;
     });
   }
-  return manager.nsps[namespace];
+  return sockets.get(namespace) as SocketIOClient.Socket;
 }
 
 export const getTranslations = async () => {
   console.debug('Getting translations');
   return new Promise((resolve) => {
-    getSocket('/', true).emit('translations', (translations) => {
-      console.debug({translations});
-      setTranslations(translations);
-      resolve(translations);
-    });
+    const loop = setInterval(() => {
+      console.log(getSocket('/', true));
+      getSocket('/', true).emit('translations', (translations) => {
+        clearInterval(loop);
+        console.debug({translations});
+        setTranslations(translations);
+        resolve(translations);
+      });
+    }, 2000);
   });
 };
 


### PR DESCRIPTION
Seems like manager was not good at keeping several sockets running in
background. I moved back to mapping sockets and forcing new connections
to each socket. This should remove issues with infinite loading of several pages

Fixes #3763

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
