### PR TITLE
feat(discord): add viewers in edited discord embed

### DIFF
--- a/src/bot/integrations/discord.ts
+++ b/src/bot/integrations/discord.ts
@@ -121,6 +121,7 @@ class Discord extends Integration {
           { name: prepare('webpanel.responses.variable.game'), value: api.stats.currentGame},
           { name: prepare('webpanel.responses.variable.title'), value: api.stats.currentTitle},
           { name: prepare('integrations.discord.started_at'), value: this.embedStartedAt, inline: true},
+          { name: prepare('webpanel.viewers'), value: api.stats.currentViewers, inline: true},
           { name: prepare('webpanel.views'), value: api.stats.currentViews, inline: true},
           { name: prepare('webpanel.followers'), value: api.stats.currentFollowers, inline: true},
         ]);


### PR DESCRIPTION
I do not think viewers on first alert will be useful.

However, viewers in edited embed is very useful, but we need change interval from 10 minutes to 1.

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
