### PR TITLE
feat(customvariables): add source attribute to sender

### DIFF
--- a/src/bot/commons.ts
+++ b/src/bot/commons.ts
@@ -37,9 +37,9 @@ export async function parserReply(response: string | Promise<string>, opts: { se
   };
   const messageToSend = await (async () => {
     if (opts.attr?.skip) {
-      return prepare(await response as string, { ...opts, sender: senderObject.discord ? senderObject.discord.author : senderObject }, false);
+      return prepare(await response as string, { ...opts, sender: senderObject.discord ? { ...senderObject, discord: senderObject.discord.author } : senderObject }, false);
     } else {
-      return await new Message(await response as string).parse({ ...opts, sender: senderObject.discord ? senderObject.discord.author : senderObject }) as string;
+      return await new Message(await response as string).parse({ ...opts, sender: senderObject.discord ? { ...senderObject, discord: senderObject.discord.author } : senderObject }) as string;
     }
   })();
   if (opts.sender.discord) {

--- a/src/bot/message.ts
+++ b/src/bot/message.ts
@@ -282,7 +282,10 @@ class Message {
             return state.isOk && !state.isEval ? state.setValue : state.updated.currentValue;
           }
         }
-        return customvariables.getValueOf(variable, { sender: attr.sender, param: attr.param });
+        return customvariables.getValueOf(variable, {
+          sender: { ...attr.sender, source: typeof attr.sender.discord === 'undefined' ? 'twitch' : 'discord' },
+          param: attr.param,
+        });
       },
       // force quiet variable set
       '$!_#': async (variable: string) => {
@@ -291,7 +294,10 @@ class Message {
           const state = await customvariables.setValueOf(variable, attr.param, { sender: attr.sender });
           return state.updated.currentValue;
         }
-        return customvariables.getValueOf(variable, { sender: attr.sender, param: attr.param });
+        return customvariables.getValueOf(variable, {
+          sender: { ...attr.sender, source: typeof attr.sender.discord === 'undefined' ? 'twitch' : 'discord' },
+          param: attr.param,
+        });
       },
       // force full quiet variable
       '$!!_#': async (variable: string) => {

--- a/src/bot/registries/text.ts
+++ b/src/bot/registries/text.ts
@@ -46,7 +46,7 @@ class Text extends Registry {
         const item = await getRepository(TextEntity).findOneOrFail({ id: opts.id });
         let text = item.text;
         if (opts.parseText) {
-          text = await new Message(await customvariables.executeVariablesInText(text)).parse();
+          text = await new Message(await customvariables.executeVariablesInText(text, null)).parse();
         }
         callback(null, {...item, text});
       } catch(e) {

--- a/src/bot/systems/alias.ts
+++ b/src/bot/systems/alias.ts
@@ -124,7 +124,14 @@ class Alias extends System {
         }
         if (getFromViewersCache(opts.sender.userId, alias.permission)) {
           // process custom variables
-          const response = await customvariables.executeVariablesInText(opts.message.replace(replace, alias.command));
+          const response = await customvariables.executeVariablesInText(
+            opts.message.replace(replace, alias.command), {
+              sender: {
+                userId: opts.sender.userId,
+                username: opts.sender.username,
+                source: typeof opts.sender.discord === 'undefined' ? 'twitch' : 'discord',
+              },
+            });
           debug('alias.process', response);
           const responses = await p.command(opts.sender, response, true);
           debug('alias.process', responses);

--- a/src/panel/views/registries/custom-variables/custom-variables-code.txt
+++ b/src/panel/views/registries/custom-variables/custom-variables-code.txt
@@ -8,6 +8,7 @@
   sender?: { // (only in custom commands, keyword)
     username: string,
     userId: number,
+    source: 'twitch' | 'discord'
   }
   random: {
     online: {


### PR DESCRIPTION
Source attribute can contain twitch or discord value dependant on
source of user command

Fixes https://community.sogebot.xyz/t/get-custom-variable-script-trigger-source/128

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
