### PR TITLE
feat(spotify): use queue endpoint for song request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sogebot",
-  "version": "11.8.4",
+  "version": "11.9.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
New endpoint was introduced on spotify web api and we can
now directly request songs into queue. Removed playlist swapping
which was used to mitigate queue behavior.

Fixes #3964

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
