### PR TITLE
fix(api): use old API as well to change game

### DIFF
--- a/src/bot/oauth.ts
+++ b/src/bot/oauth.ts
@@ -58,6 +58,7 @@ class OAuth extends Core {
   @settings('broadcaster', true)
   @ui({ type: 'checklist', current: 'broadcasterCurrentScopes' })
   public broadcasterExpectedScopes: string[] = [
+    'channel_editor',
     'chat:read',
     'chat:edit',
     'channel:moderate',
@@ -74,7 +75,7 @@ class OAuth extends Core {
 
   @ui({
     type: 'link',
-    href: 'https://twitchtokengenerator.com/quick/3hr2uOHy5B',
+    href: 'https://twitchtokengenerator.com/quick/XH6B7JteDO',
     class: 'btn btn-primary btn-block',
     text: 'commons.generate',
     target: '_blank',


### PR DESCRIPTION
Due to bug on Twitch side, modify of channel informations are not
propagated correctly through Twitch. We need to use currently old API
as well to be sure that game is changed across Twitch

###### CHECKLIST

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are changed or added
- [ ] documentation is changed or added
- [ ] locales are changed or added
- [ ] db relationship (tools/database) are changed or added
- [ ] commit message follows [commit guidelines](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md#commit-guidelines)
