### PR TITLE
fix(api): use getChannelInformation on online stream

### DIFF
--- a/src/bot/helpers/api/retries.ts
+++ b/src/bot/helpers/api/retries.ts
@@ -5,21 +5,14 @@ function setCurrentRetries(value: typeof curRetries) {
   curRetries = value;
 }
 
-let getCurrentStreamData = 0;
 let getChannelInformation = 0;
 let getChannelSubscribers = 0;
 const retries = {
-  set getCurrentStreamData (value: typeof getCurrentStreamData) {
-    getCurrentStreamData = value;
-  },
   set getChannelInformation (value: typeof getChannelInformation) {
     getChannelInformation = value;
   },
   set getChannelSubscribers (value: typeof getChannelSubscribers) {
     getChannelSubscribers = value;
-  },
-  get getCurrentStreamData() {
-    return getCurrentStreamData;
   },
   get getChannelInformation() {
     return getChannelInformation;
@@ -30,5 +23,5 @@ const retries = {
 };
 
 export {
-  maxRetries, curRetries, setCurrentRetries, retries, 
+  maxRetries, curRetries, setCurrentRetries, retries,
 };

--- a/src/bot/microservices/setTitleAndGame.ts
+++ b/src/bot/microservices/setTitleAndGame.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 import { defaults, isNil } from 'lodash';
 
 import {
-  calls, gameCache, gameOrTitleChangedManually, rawStatus, retries, setRateLimit, stats,
+  calls, gameCache, gameOrTitleChangedManually, rawStatus, setRateLimit, stats,
 } from '../helpers/api';
 import { parseTitle } from '../helpers/api/parseTitle';
 import { eventEmitter } from '../helpers/events/emitter';
@@ -130,7 +130,6 @@ async function setTitleAndGame (args: { title?: string | null; game?: string | 
       stats.value.currentTitle = args.title;
     }
     gameOrTitleChangedManually.value = true;
-    retries.getCurrentStreamData = 0;
     return responses;
   }
   return { response: '', status: false };


### PR DESCRIPTION
Before this change we rely on getCurrentStreamData, but
this caused several issues, namely with getting title outside of a bot and
trigger proper updates

Fixes https://discord.com/channels/317348946144002050/619437014001123338/821164843406852167

###### CHECKLIST

- [ ] I read [contributing docs](https://github.com/sogehige/sogeBot/blob/master/CONTRIBUTING.md)